### PR TITLE
fix(env): update SEAI U-Net environments | AIOD-220

### DIFF
--- a/modules/models/envs/cuda/conda_seai_unet.yml
+++ b/modules/models/envs/cuda/conda_seai_unet.yml
@@ -1,11 +1,23 @@
 name: unet_conda
 channels:
   - conda-forge
+  - defaults
 dependencies:
   - python=3.11
+  - pytorch
+  - torchvision
+  - numpy
+  - numba
+  - scipy
+  - matplotlib
+  - scikit-image
+  - beautifulsoup4
   - pyyaml
+  - tqdm
+  - imagecodecs
+  - git
+  - openssh
   - pip
   - pip:
-    - git+https://github.com/FrancisCrickInstitute/em-segment-pytorch.git@er-update-reqs
-    - imagecodecs
+    - git+https://github.com/FrancisCrickInstitute/em-segment-pytorch.git
     - git+https://github.com/FrancisCrickInstitute/aiod_utils.git

--- a/modules/models/envs/generic/conda_seai_unet.yml
+++ b/modules/models/envs/generic/conda_seai_unet.yml
@@ -1,12 +1,23 @@
 name: unet_conda
 channels:
-  - defaults
   - conda-forge
+  - defaults
 dependencies:
   - python=3.11
+  - pytorch
+  - torchvision
+  - numpy
+  - numba
+  - scipy
+  - matplotlib
+  - scikit-image
+  - beautifulsoup4
   - pyyaml
+  - tqdm
+  - git
+  - openssh
+  - imagecodecs
   - pip
   - pip:
     - git+https://github.com/FrancisCrickInstitute/em-segment-pytorch.git
-    - imagecodecs
     - git+https://github.com/FrancisCrickInstitute/aiod_utils.git


### PR DESCRIPTION
Update SEAI U-Net environment definitions to align with recent changes.

Depends on PR https://github.com/FrancisCrickInstitute/em-segment-pytorch/pull/17 being merged first.

To test the changes now, use my development branch in line 21:

```yaml
  - pip:
    - git+ssh://git@github.com/FrancisCrickInstitute/em-segment-pytorch.git@AIOD-220-update-env-pytorchv2
```

Related: AIOD-220