### PR TITLE
AIOD-274: Expose output mask parameters

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -44,8 +44,8 @@ def validateParams(params) {
         errors << "Invalid output_format: ${params.output_format}. Must be one of 'rle' or 'tiff'."
 
     // Check output mask type is either binary or instance, used for outputs
-    if ( !["binary", "instance"].contains(params.output_mask_type?.toLowerCase()) )
-        errors << "Invalid output_mask_type: ${params.output_mask_type}. Must be one of 'binary' or 'instance'."
+    if ( !['auto', 'binary', 'instance'].contains(params.output_mask_type?.toLowerCase()) )
+        errors << "Invalid output_mask_type: ${params.output_mask_type}. Must be one of 'binary', 'instance', or 'auto'."
 
     if ( errors ) {
         log.error "Parameter validation failed:\n" + errors.join("\n")

--- a/main.nf
+++ b/main.nf
@@ -39,6 +39,14 @@ def validateParams(params) {
     if ( params.img_dir && !file(params.img_dir).exists() ) 
         errors << "img_dir does not exist: ${params.img_dir}"
 
+    // Check output mask format is custom .rle or .tiff format
+    if ( !['rle', 'tiff'].contains(params.output_format?.toLowerCase()) )
+        errors << "Invalid output_format: ${params.output_format}. Must be one of 'rle' or 'tiff'."
+
+    // Check output mask type is either binary or instance, used for outputs
+    if ( !["binary", "instance"].contains(params.output_mask_type?.toLowerCase()) )
+        errors << "Invalid output_mask_type: ${params.output_mask_type}. Must be one of 'binary' or 'instance'."
+
     if ( errors ) {
         log.error "Parameter validation failed:\n" + errors.join("\n")
         exit 1
@@ -49,7 +57,7 @@ validateParams(params)
 
 def resolvedParamHash = params.param_hash ?: {
     // Exclude params that don't affect output content
-    def excluded = ['help', 'param_hash', 'root_dir'] as Set
+    def excluded = ['help', 'param_hash', 'root_dir', 'output_format'] as Set
     def src = params
         .findAll { k, _v -> !(k in excluded) }
         .sort()
@@ -215,7 +223,8 @@ workflow {
         mask_output_dir,
         config_ch,
         chkpt_ch,
-        params.model_type
+        params.model_type,
+        params.output_mask_type.toLowerCase()
     ).mask
 
     // Group all the outputs per image together to combine
@@ -233,7 +242,7 @@ workflow {
     }
     | set { mask_ch }
 
-    combineStacks( mask_ch, params.postprocess )
+    combineStacks( mask_ch, params.postprocess, params.output_format.toLowerCase(), params.output_mask_type.toLowerCase() )
 }
 
 // Useful output upon completion, one way or another

--- a/modules/models/main.nf
+++ b/modules/models/main.nf
@@ -121,6 +121,7 @@ process runModel {
     path model_config
     path model_chkpt
     val model_type
+    val output_mask_type
 
     output:
     tuple val("${image_path.baseName}"), val(meta), val(mask_fname), val(mask_output_dir), path("${mask_fname}_x${idxs[0]}-${idxs[1]}_y${idxs[2]}-${idxs[3]}_z${idxs[4]}-${idxs[5]}.rle"), emit: mask
@@ -136,7 +137,8 @@ process runModel {
     --model-config ${model_config} \
     --idxs ${idxs.join(" ")} \
     --channels ${meta.channels} \
-    --num-slices ${meta.num_slices}
+    --num-slices ${meta.num_slices} \
+    --output-mask-type ${output_mask_type}
     """
 }
 
@@ -152,9 +154,11 @@ process combineStacks {
     input:
     tuple val(img_simplename), val(meta), val(model), val(mask_fname), val(mask_output_dir), path(masks, arity: '1..*')
     val postprocess
+    val output_format
+    val output_mask_type
 
     output:
-    path("${mask_fname}_all.rle")
+    path("${mask_fname}_all.${output_format}")
 
     script:
     def postprocess = postprocess ? "--postprocess" : ""
@@ -169,6 +173,8 @@ process combineStacks {
     --image-size ${meta.num_slices} ${meta.height} ${meta.width} \
     --overlap $overlap \
     --iou-threshold ${params.iou_threshold} \
+    --output-format ${output_format} \
+    --output-mask-type ${output_mask_type} \
     ${postprocess}
     """
 }

--- a/modules/models/main.nf
+++ b/modules/models/main.nf
@@ -34,7 +34,7 @@ process splitStacks {
     path model_chkpt
 
     output:
-    path "${csv_path}", emit: csv_file
+    path "split_${csv_path}", emit: csv_file
 
     script:
     // Nextflow must have a string of comma separated values as input params, so split them here
@@ -44,7 +44,7 @@ process splitStacks {
     """
     python ${moduleDir}/resources/usr/bin/create_splits.py \
     --img-csv ${csv_path} \
-    --output-csv ${csv_path} \
+    --output-csv split_${csv_path} \
     --num-substacks $num_substacks \
     --overlap $overlap
     """

--- a/modules/models/resources/usr/bin/combine_stacks.py
+++ b/modules/models/resources/usr/bin/combine_stacks.py
@@ -12,6 +12,7 @@ from numba.core import types
 from numba.typed import Dict
 import numpy as np
 import skimage.measure
+import tifffile
 from skimage.segmentation import relabel_sequential
 from tqdm import tqdm
 
@@ -334,6 +335,20 @@ if __name__ == "__main__":
         default=0.8,
         help="IoU threshold for aligning masks (in SAM)",
     )
+    parser.add_argument(
+        "--output-format",
+        required=False,
+        default="rle",
+        choices=["rle", "tiff"],
+        help="Output format for the combined masks ('rle' or 'tiff')",
+    )
+    parser.add_argument(
+        "--output-mask-type",
+        required=False,
+        default="instance",
+        choices=["binary", "instance"],
+        help="Mask type of the combined output ('binary' or 'instance')",
+    )
 
     cli_args = parser.parse_args()
 
@@ -375,27 +390,39 @@ if __name__ == "__main__":
     mem_used = psutil.Process(os.getpid()).memory_info().rss / (1024.0**3)
     print(f"Memory used in combination: {mem_used:.2f} GB")
     # Save the masks
-    save_path = f"{cli_args.mask_fname}_all.rle"
+    output_format = cli_args.output_format.lower()
+    save_path = f"{cli_args.mask_fname}_all.{output_format}"
     # Get downsample factor for metadata if used
     # NOTE: Our Napari plugin uses this as an identifier to rescale for visualization
     # FIXME: This is brittle and poor, the params should be extracted from the preprocess params
     # Which themselves should be tied to the image that they produced
     if "Downsample" in cli_args.mask_fname:
         downsample_factor = get_downsample_factor(filename=cli_args.mask_fname)
-        # Extract the downsample factor from the filename
         metadata = {"downsample_factor": downsample_factor}
     else:
         metadata = {}
-    # Reuse mask_type from decoded patches to avoid expensive check_mask_type()
-    encoded_masks = aiod_rle.encode(
-        combined_masks,
-        mask_type=mask_type_from_file,
-        metadata=metadata,
-    )
-    # Free up memory (though too late at this point)
+    if output_format == "tiff":
+        # Convert to bool for binary masks so downstream tools get a clean binary image
+        if cli_args.output_mask_type == "binary":
+            # Convert to bool for quick binarisation
+            combined_masks = combined_masks.astype(bool)
+            # Convert to uint8 and ensure max is 255 for contrasst maximisation (easier display)
+            combined_masks = combined_masks.astype(np.uint8)
+            if combined_masks.max() == 1:
+                combined_masks *= 255
+        combined_masks = combined_masks.astype(bool) if cli_args.output_mask_type == "binary" else combined_masks
+        # metadata dict is serialised as JSON into the TIFF ImageDescription tag
+        tifffile.imwrite(save_path, combined_masks, metadata=metadata)
+    else:
+        # Reuse mask_type from decoded patches; fall back to the CLI value if absent
+        encoded_masks = aiod_rle.encode(
+            combined_masks,
+            mask_type=mask_type_from_file or cli_args.output_mask_type,
+            metadata=metadata,
+        )
+        # Free up memory (though too late at this point)
+        aiod_rle.save_encoding(rle=encoded_masks, fpath=save_path)
     del combined_masks
-    # Save the masks
-    aiod_rle.save_encoding(rle=encoded_masks, fpath=save_path)
     # Remove the (symlinked) individual masks now that they are combined
     for mask_path in cli_args.masks:
         (Path(cli_args.output_dir) / mask_path).unlink()

--- a/modules/models/resources/usr/bin/combine_stacks.py
+++ b/modules/models/resources/usr/bin/combine_stacks.py
@@ -346,7 +346,7 @@ if __name__ == "__main__":
         "--output-mask-type",
         required=False,
         default="instance",
-        choices=["binary", "instance"],
+        choices=["auto", "binary", "instance"],
         help="Mask type of the combined output ('binary' or 'instance')",
     )
 
@@ -402,22 +402,20 @@ if __name__ == "__main__":
     else:
         metadata = {}
     if output_format == "tiff":
-        # Convert to bool for binary masks so downstream tools get a clean binary image
-        if cli_args.output_mask_type == "binary":
-            # Convert to bool for quick binarisation
-            combined_masks = combined_masks.astype(bool)
-            # Convert to uint8 and ensure max is 255 for contrasst maximisation (easier display)
-            combined_masks = combined_masks.astype(np.uint8)
-            if combined_masks.max() == 1:
-                combined_masks *= 255
-        combined_masks = combined_masks.astype(bool) if cli_args.output_mask_type == "binary" else combined_masks
+        # Resolve 'auto' using the mask type recorded in the individual patches
+        resolved_mask_type = mask_type_from_file if cli_args.output_mask_type == "auto" else cli_args.output_mask_type
+        # Convert binary masks to uint8 0/255 for clean display
+        if resolved_mask_type == "binary":
+            # Convert to binary uint8 with 0/255 values for clean display in downstream tools
+            combined_masks = (combined_masks > 0) * np.uint8(255)
         # metadata dict is serialised as JSON into the TIFF ImageDescription tag
-        tifffile.imwrite(save_path, combined_masks, metadata=metadata)
+        tifffile.imwrite(save_path, combined_masks, metadata=metadata, imagej=True)
     else:
-        # Reuse mask_type from decoded patches; fall back to the CLI value if absent
+        # Reuse mask_type from decoded patches; fall back to CLI value (skip if 'auto' and absent)
+        resolved_mask_type = mask_type_from_file or (cli_args.output_mask_type if cli_args.output_mask_type != "auto" else None)
         encoded_masks = aiod_rle.encode(
             combined_masks,
-            mask_type=mask_type_from_file or cli_args.output_mask_type,
+            mask_type=resolved_mask_type,
             metadata=metadata,
         )
         # Free up memory (though too late at this point)

--- a/modules/models/resources/usr/bin/run_cellpose.py
+++ b/modules/models/resources/usr/bin/run_cellpose.py
@@ -84,5 +84,5 @@ if __name__ == "__main__":
         save_name=cli_args.mask_fname,
         idxs=cli_args.idxs,
         config=config,
-        output_mask_type=cli_args.output_mask_type,
+        output_mask_type=cli_args.output_mask_type if cli_args.output_mask_type != "auto" else "instance",
     )

--- a/modules/models/resources/usr/bin/run_cellpose.py
+++ b/modules/models/resources/usr/bin/run_cellpose.py
@@ -13,6 +13,7 @@ def run_cellpose(
     save_name: str,
     idxs: list[int, ...],
     config: dict,
+    output_mask_type: str,
 ):
     # Extract model config arguments
     masks, _, _, _ = cp_model.eval(
@@ -31,7 +32,7 @@ def run_cellpose(
         min_size=config["min_size"],
     )
 
-    save_masks(Path(save_dir), save_name, masks, idxs=idxs, mask_type="instance")
+    save_masks(Path(save_dir), save_name, masks, idxs=idxs, mask_type=output_mask_type)
 
 
 if __name__ == "__main__":
@@ -83,4 +84,5 @@ if __name__ == "__main__":
         save_name=cli_args.mask_fname,
         idxs=cli_args.idxs,
         config=config,
+        output_mask_type=cli_args.output_mask_type,
     )

--- a/modules/models/resources/usr/bin/run_cellposesam.py
+++ b/modules/models/resources/usr/bin/run_cellposesam.py
@@ -88,5 +88,5 @@ if __name__ == "__main__":
         config=config,
         model_chkpt=cli_args.model_chkpt,
         device=device,
-        output_mask_type=cli_args.output_mask_type,
+        output_mask_type=cli_args.output_mask_type if cli_args.output_mask_type != "auto" else "instance",
     )

--- a/modules/models/resources/usr/bin/run_cellposesam.py
+++ b/modules/models/resources/usr/bin/run_cellposesam.py
@@ -16,6 +16,7 @@ def run_cellpose(
     config: dict,
     model_chkpt: str,
     device: torch.device,
+    output_mask_type: str,
 ):
     # NOTE: This is just a link to the Cellpose-SAM model, but circumvents Cellpose's fixed model location
     # Initialize Cellpose-SAM model
@@ -40,7 +41,7 @@ def run_cellpose(
         max_size_fraction=config["max_size_fraction"],
     )
 
-    save_masks(Path(save_dir), save_name, masks, idxs=idxs, mask_type="instance")
+    save_masks(Path(save_dir), save_name, masks, idxs=idxs, mask_type=output_mask_type)
 
 
 if __name__ == "__main__":
@@ -87,4 +88,5 @@ if __name__ == "__main__":
         config=config,
         model_chkpt=cli_args.model_chkpt,
         device=device,
+        output_mask_type=cli_args.output_mask_type,
     )

--- a/modules/models/resources/usr/bin/run_empanada.py
+++ b/modules/models/resources/usr/bin/run_empanada.py
@@ -397,5 +397,5 @@ if __name__ == "__main__":
         save_name=cli_args.mask_fname,
         masks=pan_seg,
         idxs=cli_args.idxs,
-        mask_type=cli_args.output_mask_type,
+        mask_type=cli_args.output_mask_type if cli_args.output_mask_type != "auto" else "binary",
     )

--- a/modules/models/resources/usr/bin/run_empanada.py
+++ b/modules/models/resources/usr/bin/run_empanada.py
@@ -397,5 +397,5 @@ if __name__ == "__main__":
         save_name=cli_args.mask_fname,
         masks=pan_seg,
         idxs=cli_args.idxs,
-        mask_type="binary",  # Much faster this way
+        mask_type=cli_args.output_mask_type,
     )

--- a/modules/models/resources/usr/bin/run_plantseg2.py
+++ b/modules/models/resources/usr/bin/run_plantseg2.py
@@ -146,5 +146,5 @@ if __name__ == "__main__":
         idxs=cli_args.idxs,
         img=img,
         config=config,
-        output_mask_type=cli_args.output_mask_type
+        output_mask_type=cli_args.output_mask_type if cli_args.output_mask_type != "auto" else "instance"
     )

--- a/modules/models/resources/usr/bin/run_plantseg2.py
+++ b/modules/models/resources/usr/bin/run_plantseg2.py
@@ -14,6 +14,7 @@ def run_plantseg2(
     idxs: list[int, ...],
     img: np.ndarray,
     config: dict,
+    output_mask_type: str,
 ):
     """Run PlantSeg2 pipeline: prediction -> watershed -> GASP.
 
@@ -96,7 +97,7 @@ def run_plantseg2(
     print(f"GASP complete. Segmentation shape: {segmentation.shape}, unique labels: {len(np.unique(segmentation))}")
 
     # Save the final segmentation
-    save_masks(Path(save_dir), save_name, segmentation, idxs=idxs, mask_type="instance")
+    save_masks(Path(save_dir), save_name, segmentation, idxs=idxs, mask_type=output_mask_type)
 
 
 if __name__ == "__main__":
@@ -145,4 +146,5 @@ if __name__ == "__main__":
         idxs=cli_args.idxs,
         img=img,
         config=config,
+        output_mask_type=cli_args.output_mask_type
     )

--- a/modules/models/resources/usr/bin/run_sam.py
+++ b/modules/models/resources/usr/bin/run_sam.py
@@ -187,5 +187,5 @@ if __name__ == "__main__":
         model_chkpt=cli_args.model_chkpt,
         model_config=model_config,
         idxs=cli_args.idxs,
-        output_mask_type=cli_args.output_mask_type,
+        output_mask_type=cli_args.output_mask_type if cli_args.output_mask_type != "auto" else "instance",
     )

--- a/modules/models/resources/usr/bin/run_sam.py
+++ b/modules/models/resources/usr/bin/run_sam.py
@@ -26,6 +26,7 @@ def run_sam(
     model_chkpt: Union[Path, str],
     model_config: dict,
     idxs: list[int, ...],
+    output_mask_type: str,
 ):
     # Handle extra finetuned/other models
     if "MicroSAM" in model_type:
@@ -75,7 +76,7 @@ def run_sam(
             raise ValueError("Cannot handle a stack of multi-channel images")
     else:
         raise ValueError("Can only handle an image, or stack of images!")
-    save_masks(save_dir, save_name, all_masks, idxs=idxs, mask_type="instance")
+    save_masks(save_dir, save_name, all_masks, idxs=idxs, mask_type=output_mask_type)
     pbar.close()
     return img, all_masks
 
@@ -186,4 +187,5 @@ if __name__ == "__main__":
         model_chkpt=cli_args.model_chkpt,
         model_config=model_config,
         idxs=cli_args.idxs,
+        output_mask_type=cli_args.output_mask_type,
     )

--- a/modules/models/resources/usr/bin/run_sam2.py
+++ b/modules/models/resources/usr/bin/run_sam2.py
@@ -48,6 +48,7 @@ def run_sam2(
     model_chkpt: Union[Path, str],
     model_config: dict,
     idxs: list[int, ...],
+    output_mask_type: str,
 ):
     # Need to handle model types and get the appropriate model
     if model_type == "default":
@@ -90,7 +91,7 @@ def run_sam2(
             raise ValueError("Cannot handle a stack of multi-channel images")
     else:
         raise ValueError("Can only handle an image, or stack of images!")
-    save_masks(save_dir, save_name, all_masks, idxs=idxs, mask_type="instance")
+    save_masks(save_dir, save_name, all_masks, idxs=idxs, mask_type=output_mask_type)
     return img, all_masks
 
 
@@ -209,4 +210,5 @@ if __name__ == "__main__":
         model_chkpt=cli_args.model_chkpt,
         model_config=model_config,
         idxs=cli_args.idxs,
+        output_mask_type=cli_args.output_mask_type
     )

--- a/modules/models/resources/usr/bin/run_sam2.py
+++ b/modules/models/resources/usr/bin/run_sam2.py
@@ -210,5 +210,5 @@ if __name__ == "__main__":
         model_chkpt=cli_args.model_chkpt,
         model_config=model_config,
         idxs=cli_args.idxs,
-        output_mask_type=cli_args.output_mask_type
+        output_mask_type=cli_args.output_mask_type if cli_args.output_mask_type != "auto" else "instance"
     )

--- a/modules/models/resources/usr/bin/run_seai_unet.py
+++ b/modules/models/resources/usr/bin/run_seai_unet.py
@@ -51,5 +51,5 @@ if __name__ == "__main__":
         save_name=cli_args.mask_fname,
         masks=labelled_stack,
         idxs=cli_args.idxs,
-        mask_type=cli_args.output_mask_type,
+        mask_type=cli_args.output_mask_type if cli_args.output_mask_type != "auto" else "binary",
     )

--- a/modules/models/resources/usr/bin/run_seai_unet.py
+++ b/modules/models/resources/usr/bin/run_seai_unet.py
@@ -51,5 +51,5 @@ if __name__ == "__main__":
         save_name=cli_args.mask_fname,
         masks=labelled_stack,
         idxs=cli_args.idxs,
-        mask_type="binary",
+        mask_type=cli_args.output_mask_type,
     )

--- a/modules/models/resources/usr/bin/setup_model.py
+++ b/modules/models/resources/usr/bin/setup_model.py
@@ -48,6 +48,7 @@ def main(model_name: str, model_version: str, model_task: str, user_config: str 
     except KeyError:
         try:
             model_info = versions[model_version.replace("-", " ")].tasks[model_task]
+            model_version = model_version.replace("-", " ")
         except KeyError:
             raise KeyError(
                 f"Model version '{model_version}' with task '{model_task}' not found in the registry! Model version must be one of {versions.keys()}"

--- a/modules/models/resources/usr/bin/utils.py
+++ b/modules/models/resources/usr/bin/utils.py
@@ -59,9 +59,9 @@ def create_argparser_inference():
     )
     parser.add_argument(
         "--output-mask-type",
-        default="instance",
-        choices=["binary", "instance"],
-        help="Mask type to store in output ('binary' or 'instance')",
+        default="auto",
+        choices=["binary", "instance", "auto"],
+        help="Mask type to store in output ('binary', 'instance', or 'auto' to use the model default)",
     )
 
     return parser

--- a/modules/models/resources/usr/bin/utils.py
+++ b/modules/models/resources/usr/bin/utils.py
@@ -57,6 +57,12 @@ def create_argparser_inference():
     parser.add_argument(
         "--num-slices", type=int, help="Number of Z slices in the input image"
     )
+    parser.add_argument(
+        "--output-mask-type",
+        default="instance",
+        choices=["binary", "instance"],
+        help="Mask type to store in output ('binary' or 'instance')",
+    )
 
     return parser
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -60,6 +60,9 @@ params {
     // Postprocessing parameters
     postprocess = false
     iou_threshold = 0.8
+    // Output parameters
+    output_format = "rle"
+    output_mask_type = "binary"
 }
 
 profiles {

--- a/nextflow.config
+++ b/nextflow.config
@@ -62,7 +62,7 @@ params {
     iou_threshold = 0.8
     // Output parameters
     output_format = "rle"
-    output_mask_type = "binary"
+    output_mask_type = "auto"
 }
 
 profiles {


### PR DESCRIPTION
Add `output_format` and `output_mask_type` parameters to allow specification of e.g. TIFF (instead of .rle), and also to allow control over the type ("binary" or "instance").