### PR TITLE
AIOD-139 dynamic substack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ var/
 # Nextflow ignores
 .nextflow*
 **/work/*
+.nf-test*

--- a/modules/models/main.nf
+++ b/modules/models/main.nf
@@ -41,12 +41,16 @@ process splitStacks {
     // https://github.com/nextflow-io/nextflow/issues/3595 should track this
     num_substacks = params.num_substacks.replace(",", " ")
     overlap = params.overlap.replace(",", " ")
+    def mem_arg = (params.containsKey('memory_per_job') && params.memory_per_job) \
+        ? "--memory-per-job ${(params.memory_per_job as nextflow.util.MemoryUnit).toBytes()}" \
+        : ""
     """
     python ${moduleDir}/resources/usr/bin/create_splits.py \
     --img-csv ${csv_path} \
     --output-csv ${csv_path} \
     --num-substacks $num_substacks \
-    --overlap $overlap
+    --overlap $overlap \
+    $mem_arg
     """
 }
 
@@ -107,7 +111,7 @@ process setupModel {
 }
 
 process runModel {
-    label 'small_gpu'
+    label 'gpu_process'
     conda "${moduleDir}/envs/${task.ext.condaDir}/conda_${params.model}.yml"
     // Symlink to where AIoD Napari plugin file watcher is looking
     publishDir "$mask_output_dir"

--- a/modules/models/resources/usr/bin/create_splits.py
+++ b/modules/models/resources/usr/bin/create_splits.py
@@ -103,7 +103,6 @@ if __name__ == "__main__":
             max_substack_size = compute_max_substack_size(
                 memory_bytes=args.memory_per_job,
                 dtype=img_dtype,
-                n_channels=int(row["channels"]),
                 image_shape=img_shape,
             )
         else:

--- a/modules/models/resources/usr/bin/create_splits.py
+++ b/modules/models/resources/usr/bin/create_splits.py
@@ -2,16 +2,14 @@ from collections import defaultdict
 from pathlib import Path
 
 import pandas as pd
-
+from aiod_utils.io import load_image
 from aiod_utils.stacks import (
-    Stack,
     MAX_SUBSTACK_SIZE,
+    Stack,
     calc_num_stacks,
     compute_max_substack_size,
     generate_stack_indices,
 )
-from aiod_utils.io import load_image
-
 
 if __name__ == "__main__":
     # Get the command line arguments
@@ -95,9 +93,11 @@ if __name__ == "__main__":
             try:
                 img_dtype = str(load_image(img_path).dtype)
             except Exception:
-                img_dtype = 'float32'  # conservative fallback
+                img_dtype = "float32"  # conservative fallback
         else:
-            img_dtype = str(row["dtype"]) if pd.notna(row["dtype"]) else 'float32'  # conservative fallback 
+            img_dtype = (
+                str(row["dtype"]) if pd.notna(row["dtype"]) else "float32"
+            )  # conservative fallback
         # Compute the maximum substack size: dynamic if memory_per_job provided, else use constant
         if args.memory_per_job is not None:
             max_substack_size = compute_max_substack_size(

--- a/modules/models/resources/usr/bin/create_splits.py
+++ b/modules/models/resources/usr/bin/create_splits.py
@@ -3,7 +3,14 @@ from pathlib import Path
 
 import pandas as pd
 
-from aiod_utils.stacks import Stack, calc_num_stacks, generate_stack_indices
+from aiod_utils.stacks import (
+    Stack,
+    MAX_SUBSTACK_SIZE,
+    calc_num_stacks,
+    compute_max_substack_size,
+    generate_stack_indices,
+)
+from aiod_utils.io import load_image
 
 
 if __name__ == "__main__":
@@ -31,6 +38,13 @@ if __name__ == "__main__":
         type=str,
         help="Output csv file with stack indices",
     )
+    parser.add_argument(
+        "--memory-per-job",
+        required=False,
+        default=None,
+        type=int,
+        help="Memory available per runModel job in bytes (used to compute substack size dynamically).",
+    )
 
     args = parser.parse_args()
 
@@ -45,6 +59,7 @@ if __name__ == "__main__":
             raise ValueError(
                 f"Column '{col}' not found in input image path csv file ({img_csv_fpath})."
             )
+    fetch_dtype = "dtype" not in img_df.columns
 
     # Drop the stack info if it exists
     img_df = img_df.drop(
@@ -74,13 +89,32 @@ if __name__ == "__main__":
             depth=int(row["num_slices"]),
             channels=int(row["channels"]),
         )
+        # TODO modify napari csv export to include dtype column
+        # NOTE: If BioImage.dtype fails, will it return None? What are the possible failures here
+        if fetch_dtype:
+            try:
+                img_dtype = str(load_image(img_path).dtype)
+            except Exception:
+                img_dtype = 'float32'  # conservative fallback
+        else:
+            img_dtype = str(row["dtype"]) if pd.notna(row["dtype"]) else 'float32'  # conservative fallback 
+        # Compute the maximum substack size: dynamic if memory_per_job provided, else use constant
+        if args.memory_per_job is not None:
+            max_substack_size = compute_max_substack_size(
+                memory_bytes=args.memory_per_job,
+                dtype=img_dtype,
+                n_channels=int(row["channels"]),
+                image_shape=img_shape,
+            )
+        else:
+            max_substack_size = MAX_SUBSTACK_SIZE
         # Get the requested number of substacks (either int or 'auto' for each dimension)
         num_substacks = Stack(*args.num_substacks)
         # Ensure overlap is a tuple of floats
         overlap_fraction = Stack(*map(float, args.overlap))
         # Calculate the number of stacks and the effective shape
         num_substacks, eff_shape = calc_num_stacks(
-            img_shape, num_substacks, overlap_fraction
+            img_shape, num_substacks, overlap_fraction, max_substack_size
         )
         # Generate the stack indices
         stack_indices, num_stacks, stack_size = generate_stack_indices(

--- a/profiles/crick.conf
+++ b/profiles/crick.conf
@@ -1,3 +1,9 @@
+
+params {
+    memory_per_job = 50.GB
+}
+
+
 process {
     executor = 'slurm'
     cache = 'lenient'
@@ -7,25 +13,11 @@ process {
     errorStrategy = { task.exitStatus in 135..143 ? 'retry' : 'terminate' }
     maxRetries = 3
 
-    withLabel: small_gpu {
+    withLabel: gpu_process {
         queue = 'ga100'
         clusterOptions = '--gres=gpu:1'
-        memory = { 50.GB * task.attempt }
+        memory = { params.memory_per_job.toMemoryUnit() * task.attempt }
         time = { 15.min * task.attempt }
-    }
-
-    withLabel: medium_gpu {
-        queue = 'ga100'
-        clusterOptions = '--gres=gpu:2'
-        memory = { 100.GB * task.attempt }
-        time = { 30.min * task.attempt }
-    }
-
-    withLabel: large_gpu {
-        queue = 'ga100'
-        clusterOptions = '--gres=gpu:4'
-        memory = { 175.GB * task.attempt }
-        time = { 60.min * task.attempt }
     }
 
     withName: '!run.*' {

--- a/profiles/crick.conf
+++ b/profiles/crick.conf
@@ -16,7 +16,7 @@ process {
     withLabel: gpu_process {
         queue = 'ga100'
         clusterOptions = '--gres=gpu:1'
-        memory = { params.memory_per_job.toMemoryUnit() * task.attempt }
+        memory = { params.memory_per_job * task.attempt }
         time = { 15.min * task.attempt }
     }
 

--- a/profiles/local.conf
+++ b/profiles/local.conf
@@ -1,9 +1,14 @@
+params {
+    // Conservative default; set to available RAM on the local machine
+    memory_per_job = 8.GB
+}
+
 process {
     executor = 'local'
     debug = true
     ext.condaDir = "generic"
 
-    withLabel: small_gpu {
+    withLabel: gpu_process {
         cpus = 4
     }
 }

--- a/profiles/rosalind.conf
+++ b/profiles/rosalind.conf
@@ -1,3 +1,7 @@
+params {
+    memory_per_job = 50.GB
+}
+
 process {
     executor = 'local'
     debug = true
@@ -6,8 +10,8 @@ process {
     errorStrategy = { task.exitStatus in 135..143 ? 'retry' : 'terminate' }
     maxRetries = 3
 
-    withLabel: small_gpu {
-        memory = { 50.GB * task.attempt }
+    withLabel: gpu_process {
+        memory = { params.memory_per_job * task.attempt }
         time = { 15.min * task.attempt }
         maxForks = 1
     }

--- a/tests/assets/test_splits_input.csv
+++ b/tests/assets/test_splits_input.csv
@@ -1,0 +1,3 @@
+img_path,height,width,num_slices,channels,dtype
+/fake/path/test_image.tif,2000,400,100,1,float32
+

--- a/tests/splitStacks.nf.test
+++ b/tests/splitStacks.nf.test
@@ -1,0 +1,77 @@
+nextflow_process {
+    name "Test splitStacks"
+    script "modules/models/main.nf"
+    process "splitStacks"
+
+    // ---------------------------------------------------------------------------
+    // Smoke test: verify that splitStacks passes memory_per_job through to
+    // create_splits.py and produces the expected number of substacks.
+    //
+    // Test image: 2000 × 400 × 100, float32, 1 channel -> 2.56GB
+    // memory_per_job: 100 MB → compute_max_substack_size gives ~(1252, 250, 62)
+    //   → calc_num_stacks gives 2×2×2 = 8 substacks (1 header + 8 data rows)
+    //
+    // To run locally (requires Nextflow + conda env):
+    //   nf-test test tests/splitStacks.nf.test --profile local
+    //
+    // To run on the cluster (pre-merge CI):
+    //   nf-test test tests/splitStacks.nf.test --profile crick
+    // ---------------------------------------------------------------------------
+
+    test("8 substacks for 100 MB memory_per_job on 2000x400x100 float32 image") {
+
+        when {
+            params {
+                num_substacks   = "auto,auto,auto"
+                overlap         = "0.0,0.0,0.0"
+                memory_per_job  = "100.MB"
+                root_dir = "."
+            }
+            process {
+                """
+                input[0] = file("${projectDir}/tests/assets/test_splits_input.csv")
+                input[1] = file("${projectDir}/tests/assets/dummy_chkpt")
+                """
+            }
+        }
+
+        then {
+            assert process.success
+
+            def rows = path(process.out.csv_file.get(0)).readLines()
+            assert rows.size() - 1 == 8
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Fallback test: when memory_per_job is not set, MAX_SUBSTACK_SIZE is used
+    // and the pipeline still succeeds.
+    // ---------------------------------------------------------------------------
+
+    test("succeeds without memory_per_job (falls back to MAX_SUBSTACK_SIZE)") {
+
+        when {
+            params {
+                num_substacks = "auto,auto,auto"
+                overlap       = "0.0,0.0,0.0"
+                memory_per_job = null // Explicitly unset to test fallback
+                root_dir = "."
+            }
+            process {
+                """
+                input[0] = file("${projectDir}/tests/assets/test_splits_input.csv")
+                input[1] = file("${projectDir}/tests/assets/dummy_chkpt")
+                """
+            }
+        }
+
+        then {
+            assert process.success
+
+            def rows = path(process.out.csv_file[0]).readLines()
+            // With MAX_SUBSTACK_SIZE (5000×5000×50), this image (2000×400×100)
+            // split along depth dimension → 2 rows
+            assert rows.size() - 1 == 2 // subtract header
+        }
+    }
+}


### PR DESCRIPTION
Adds an addition "available memory" parameter to the splitStacks process which is used in `create_splits` to calculate max stack size (see https://github.com/FrancisCrickInstitute/aiod_utils/pull/7)

Currently the memory per job parameter is a profile specific parameter to be configured; future work can look at automatically querying available resources