### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update_envs.yml
+++ b/.github/workflows/update_envs.yml
@@ -12,6 +12,10 @@ on:
   repository_dispatch:
     types: [package-version-bump]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-conda-envs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/FrancisCrickInstitute/Segment-Flow/security/code-scanning/1](https://github.com/FrancisCrickInstitute/Segment-Flow/security/code-scanning/1)

Add an explicit `permissions` block to this workflow so `GITHUB_TOKEN` has only what this job needs.

Best fix here (without changing functionality): add workflow-level permissions under `on:` (or under `name:`) with:
- `contents: write` (required for `git push`)
- `pull-requests: write` (required for `gh pr create`)

This keeps behavior intact while removing reliance on inherited defaults.  
File to edit: `.github/workflows/update_envs.yml`, near the top-level keys before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
