### PR TITLE
Aiod 303

### DIFF
--- a/modules/models/resources/usr/bin/run_empanada.py
+++ b/modules/models/resources/usr/bin/run_empanada.py
@@ -193,7 +193,7 @@ def infer_3d(engine: PanopticDeepLabRenderEngine3d, img, norms, inference_kwargs
     matcher_proc.join()
     # Now propagate labels backward through stack
     axis_len = img.shape[axis]
-    for idx, rle_seg in backward_matching(rle_stack, matchers, axis_len):
+    for idx, rle_seg in backward_matching(rle_stack, matchers, min(len(rle_stack), axis_len)):
         update_trackers(rle_seg, idx, trackers)
     finish_tracking(trackers)
 
@@ -277,6 +277,17 @@ def consensus_volume(engine, trackers_dict, inference_kwargs):
 
 
 def run_3d(engine, img, norms, inference_kwargs):
+
+    print(img.shape)
+    print("Kernel size b4: ", engine.ks)
+    
+    if img.shape[0] < engine.ks:
+        engine.ks = 1
+        engine.mid_idx = 0
+        engine.reset()
+
+    print("Kernel size aftr: ", engine.ks)
+    
     # NOTE: Long-term, the pipeline would fail long before here if the data doesn't match the requested model+params
     if img.ndim == 2:
         raise ValueError("Image must be a stack for ortho/3D inference!")

--- a/modules/models/resources/usr/bin/run_empanada.py
+++ b/modules/models/resources/usr/bin/run_empanada.py
@@ -129,9 +129,7 @@ def create_trackers(engine, img_shape, axis_name, labels):
     ]
 
 
-def infer_3d(engine: PanopticDeepLabRenderEngine3d, img, norms, inference_kwargs):
-    axis_name = inference_kwargs["inference_plane"].lower()
-    axis = _AXES[axis_name]
+def infer_3d(engine: PanopticDeepLabRenderEngine3d, img, norms, inference_kwargs, axis_name, axis):
     dataset = VolumeDataset(
         img,
         axis,
@@ -277,17 +275,14 @@ def consensus_volume(engine, trackers_dict, inference_kwargs):
 
 
 def run_3d(engine, img, norms, inference_kwargs):
-
-    print(img.shape)
-    print("Kernel size b4: ", engine.ks)
-    
-    if img.shape[0] < engine.ks:
+    axis_name = inference_kwargs["inference_plane"].lower()
+    axis = _AXES[axis_name]
+    # The default ks(kernel size) is 3 which is incompatible with z = 2 images
+    if img.shape[axis] < engine.ks:
         engine.ks = 1
         engine.mid_idx = 0
         engine.reset()
 
-    print("Kernel size aftr: ", engine.ks)
-    
     # NOTE: Long-term, the pipeline would fail long before here if the data doesn't match the requested model+params
     if img.ndim == 2:
         raise ValueError("Image must be a stack for ortho/3D inference!")
@@ -300,7 +295,7 @@ def run_3d(engine, img, norms, inference_kwargs):
             img = np.moveaxis(img, 1, 0)
         elif inference_kwargs["inference_plane"] == "YZ":
             img = np.moveaxis(img, 2, 0)
-        stack, trackers = infer_3d(engine, img, norms, inference_kwargs)
+        stack, trackers = infer_3d(engine, img, norms, inference_kwargs, axis_name, axis)
         trackers_dict[inference_kwargs["inference_plane"].lower()] = trackers
         stack = postprocess_volume(engine, trackers_dict, img.shape, inference_kwargs)
     else:
@@ -308,7 +303,7 @@ def run_3d(engine, img, norms, inference_kwargs):
         stacks = []
         for plane in _AXES.keys():
             inference_kwargs["inference_plane"] = plane
-            stack, trackers = infer_3d(engine, img, norms, inference_kwargs)
+            stack, trackers = infer_3d(engine, img, norms, inference_kwargs, axis_name, axis)
             trackers_dict[plane] = trackers
             stacks.append(stack)
         stack = consensus_volume(engine, trackers_dict, inference_kwargs)


### PR DESCRIPTION
Just setting the kernel size to 1 based on if the z slices are less than the default kernel size(3)

The whole kernel size logic is used to smooth out segmentations across the slices which isn't really needed when we only have 2 slices