### PR TITLE
AIOD-307: Add check and mix in for no-op preprocessing

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -183,16 +183,30 @@ workflow {
                 ]
             }
             | set { img_ch1 }
-        // Preprocess the images, outputting one per preprocess set
+        // Preprocess the images, outputting one per non-empty preprocess set
+        // Empty sets (i.e. no-ops) are mixed in later so no copies are made
         preprocessImage( img_ch1, file(params.img_dir) )
         preprocessImage.out.prep_imgs
             | flatten()
             | map{ img -> [img.name, img] }
-            | set { img_names }
+            | set { prep_img_names }
         // Collect all CSVs together into original file
         preprocessImage.out.img_csv
             | collectFile(name: "all_img_info.csv", keepHeader: true)
             | set { all_img_info }
+        // Check for presence of any no-op sets & integrate if so
+        if ( params.preprocess.any { it instanceof List && it.isEmpty() } ) {
+            channel.fromPath(params.img_dir).splitCsv( header: true, quote: '\"' )
+                | map{ row -> [row.img_path, file(row.img_path)] }
+                | mix(prep_img_names)
+                | set { img_names }
+            all_img_info
+                | mix(channel.fromPath(params.img_dir))
+                | collectFile(name: "all_img_info.csv", keepHeader: true)
+                | set { all_img_info }
+        } else {
+            prep_img_names.set { img_names }
+        }
         // Split the image stacks into substacks (after model download completes)
         splitStacks( all_img_info, chkpt_ch )
     }

--- a/modules/models/resources/usr/bin/preprocess_image.py
+++ b/modules/models/resources/usr/bin/preprocess_image.py
@@ -48,8 +48,8 @@ if __name__ == "__main__":
     # TODO: Switch to return_dask, map over blocks, and check output as described at top
     # TODO: Specify dim order and ensure it's preserved on save
     image = load_image_data(args.img_path).squeeze()
-    # Extract all preprocessing sets
-    preprocess_methods = load_methods(args.preprocess_params)
+    # Extract all preprocessing sets (except empty no-ops)
+    preprocess_methods = load_methods(args.preprocess_params, filter_noop=True)
     # Create a new dataframe to store the new images, repeating rows per preprocessing set
     df_new = pd.concat([df_img] * len(preprocess_methods), ignore_index=True)
     # Loop over each set and preprocess
@@ -63,7 +63,7 @@ if __name__ == "__main__":
         )
         # Update the dataframe with the new image path, ensuring full path given
         df_new.loc[i, "img_path"] = fname
-        # TODO: Update size and other metadata in the dataframe, needed if downsampled
+        # Update shape info in the dataframe if downsampled/modified
         if image.shape != prep_image.shape:
             # Find the column for each of the elements, and overwrite
             # NOTE: If we add a preprocessing function that modifies number of channels, this will need to be updated

--- a/modules/models/resources/usr/bin/preprocess_image.py
+++ b/modules/models/resources/usr/bin/preprocess_image.py
@@ -44,6 +44,10 @@ if __name__ == "__main__":
     # Reconstruct full path and match with DF to only get the row for this image
     df_img["img_path"] = df_img["img_path"].apply(lambda x: Path(x).name)
     df_img = df_img.loc[df_img.img_path == args.img_path]
+    if len(df_img) == 0:
+        raise ValueError(f"No matching image found in CSV for {args.img_path}")
+    elif len(df_img) > 1:
+        raise ValueError(f"Multiple matching images found in CSV for {args.img_path}")
     # Preprocess the image
     # TODO: Switch to return_dask, map over blocks, and check output as described at top
     # TODO: Specify dim order and ensure it's preserved on save


### PR DESCRIPTION
Handle "no-op" preprocessing sets, meaning we can additionally run the original data with no preprocessing alongside multiple preprocessing sets, routing around the preprocess process to avoid data copies.