### PR TITLE
AIOD-310: Fix inconsistent passing of model parameters in user configs

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -183,16 +183,30 @@ workflow {
                 ]
             }
             | set { img_ch1 }
-        // Preprocess the images, outputting one per preprocess set
+        // Preprocess the images, outputting one per non-empty preprocess set
+        // Empty sets (i.e. no-ops) are mixed in later so no copies are made
         preprocessImage( img_ch1, file(params.img_dir) )
         preprocessImage.out.prep_imgs
             | flatten()
             | map{ img -> [img.name, img] }
-            | set { img_names }
+            | set { prep_img_names }
         // Collect all CSVs together into original file
         preprocessImage.out.img_csv
             | collectFile(name: "all_img_info.csv", keepHeader: true)
             | set { all_img_info }
+        // Check for presence of any no-op sets & integrate if so
+        if ( params.preprocess.any { it instanceof List && it.isEmpty() } ) {
+            channel.fromPath(params.img_dir).splitCsv( header: true, quote: '\"' )
+                | map{ row -> [row.img_path, file(row.img_path)] }
+                | mix(prep_img_names)
+                | set { img_names }
+            all_img_info
+                | mix(channel.fromPath(params.img_dir))
+                | collectFile(name: "all_img_info.csv", keepHeader: true)
+                | set { all_img_info }
+        } else {
+            prep_img_names.set { img_names }
+        }
         // Split the image stacks into substacks (after model download completes)
         splitStacks( all_img_info, chkpt_ch )
     }

--- a/modules/models/resources/usr/bin/preprocess_image.py
+++ b/modules/models/resources/usr/bin/preprocess_image.py
@@ -48,8 +48,8 @@ if __name__ == "__main__":
     # TODO: Switch to return_dask, map over blocks, and check output as described at top
     # TODO: Specify dim order and ensure it's preserved on save
     image = load_image_data(args.img_path).squeeze()
-    # Extract all preprocessing sets
-    preprocess_methods = load_methods(args.preprocess_params)
+    # Extract all preprocessing sets (except empty no-ops)
+    preprocess_methods = load_methods(args.preprocess_params, filter_noop=True)
     # Create a new dataframe to store the new images, repeating rows per preprocessing set
     df_new = pd.concat([df_img] * len(preprocess_methods), ignore_index=True)
     # Loop over each set and preprocess
@@ -63,7 +63,7 @@ if __name__ == "__main__":
         )
         # Update the dataframe with the new image path, ensuring full path given
         df_new.loc[i, "img_path"] = fname
-        # TODO: Update size and other metadata in the dataframe, needed if downsampled
+        # Update shape info in the dataframe if downsampled/modified
         if image.shape != prep_image.shape:
             # Find the column for each of the elements, and overwrite
             # NOTE: If we add a preprocessing function that modifies number of channels, this will need to be updated

--- a/modules/models/resources/usr/bin/preprocess_image.py
+++ b/modules/models/resources/usr/bin/preprocess_image.py
@@ -44,6 +44,10 @@ if __name__ == "__main__":
     # Reconstruct full path and match with DF to only get the row for this image
     df_img["img_path"] = df_img["img_path"].apply(lambda x: Path(x).name)
     df_img = df_img.loc[df_img.img_path == args.img_path]
+    if len(df_img) == 0:
+        raise ValueError(f"No matching image found in CSV for {args.img_path}")
+    elif len(df_img) > 1:
+        raise ValueError(f"Multiple matching images found in CSV for {args.img_path}")
     # Preprocess the image
     # TODO: Switch to return_dask, map over blocks, and check output as described at top
     # TODO: Specify dim order and ensure it's preserved on save

--- a/modules/models/resources/usr/bin/setup_model.py
+++ b/modules/models/resources/usr/bin/setup_model.py
@@ -1,4 +1,5 @@
 import argparse
+import hashlib
 import os
 import json
 from pathlib import Path
@@ -38,20 +39,25 @@ def check_access(location: str, loc_type: str) -> bool:
     return True
 
 
-def config_stem(source: str) -> str:
-    """Return the stem of a config source filename (works for both paths and URLs).
+def config_tag(source: str) -> str:
+    """Return a short tag for a config source to disambiguate storeDir entries.
 
-    Appended to config artifact filenames so that storeDir's existence check
-    becomes source-specific: changing params.model_config to a file with a
-    different name produces a different artifact filename and therefore a cache
-    miss, forcing the new config to be fetched.
+    For local files the tag is an 8-char MD5 of the file contents, so an
+    in-place edit (same path, different content) is correctly treated as a cache
+    miss.
+    For URLs the file is not yet available at setup time, so we fall back
+    to a hash of the URL string (sufficient because a URL change always implies
+    a content change).
+
     Checkpoints are intentionally excluded from this scheme — they are immutable
     and should always be served from the storeDir cache.
     """
     parsed = urlparse(source)
-    # For URLs use the URL path component; for local paths use the source directly
-    path_part = parsed.path if parsed.scheme in ("http", "https") else source
-    return Path(path_part).stem
+    if parsed.scheme in ("http", "https"):
+        # URL: hash the URL string as the best available proxy for content
+        return hashlib.md5(source.encode()).hexdigest()[:8]
+    # Local file: hash the actual contents so in-place edits are detected
+    return hashlib.md5(Path(source).read_bytes()).hexdigest()[:8]
 
 
 def main(model_name: str, model_version: str, model_task: str, user_config: str | None = None):
@@ -111,7 +117,7 @@ def main(model_name: str, model_version: str, model_task: str, user_config: str 
             raise FileNotFoundError(
                 f"User-supplied config is not accessible: {user_config}"
             )
-        model_config_name = model_version_slug + "_" + model_task + f"_config_{config_stem(user_config)}.yml"
+        model_config_name = model_version_slug + "_" + model_task + f"_config_{config_tag(user_config)}.yml"
         write_meta(
             "model_config_meta.json", model_config_name, user_config, config_location_type
         )
@@ -137,7 +143,7 @@ def main(model_name: str, model_version: str, model_task: str, user_config: str 
                 f"  Route 2 (registry default): no params defined for this model\n"
                 f"  Route 3 (registry config_path): '{model_config_location}' is not accessible"
             )
-        model_config_name = model_version_slug + "_" + model_task + f"_config_{config_stem(model_config_location)}.yml"
+        model_config_name = model_version_slug + "_" + model_task + f"_config_{config_tag(model_config_location)}.yml"
         write_meta(
             "model_config_meta.json", model_config_name, model_config_location, config_location_type
         )

--- a/modules/models/resources/usr/bin/setup_model.py
+++ b/modules/models/resources/usr/bin/setup_model.py
@@ -38,6 +38,22 @@ def check_access(location: str, loc_type: str) -> bool:
     return True
 
 
+def config_stem(source: str) -> str:
+    """Return the stem of a config source filename (works for both paths and URLs).
+
+    Appended to config artifact filenames so that storeDir's existence check
+    becomes source-specific: changing params.model_config to a file with a
+    different name produces a different artifact filename and therefore a cache
+    miss, forcing the new config to be fetched.
+    Checkpoints are intentionally excluded from this scheme — they are immutable
+    and should always be served from the storeDir cache.
+    """
+    parsed = urlparse(source)
+    # For URLs use the URL path component; for local paths use the source directly
+    path_part = parsed.path if parsed.scheme in ("http", "https") else source
+    return Path(path_part).stem
+
+
 def main(model_name: str, model_version: str, model_task: str, user_config: str | None = None):
     # Load full registry without accessibility filtering to allow precise error reporting
     manifests = load_manifests(filter_access=False)
@@ -95,13 +111,14 @@ def main(model_name: str, model_version: str, model_task: str, user_config: str 
             raise FileNotFoundError(
                 f"User-supplied config is not accessible: {user_config}"
             )
-        model_config_name = model_version_slug + "_" + model_task + "_config.yml"
+        model_config_name = model_version_slug + "_" + model_task + f"_config_{config_stem(user_config)}.yml"
         write_meta(
             "model_config_meta.json", model_config_name, user_config, config_location_type
         )
         print(f"Using user-supplied config: {user_config}")
     elif model_info.params:
-        # Route 2: generate default config from registry params
+        # Route 2: generate default config from registry params — content is deterministic
+        # for a given model version/task, so no source tag is needed.
         default_yaml = generate_default_config(manifests[model_name], model_version, model_task)
         model_config_name = model_version_slug + "_" + model_task + "_config.yml"
         config_abs_path = Path.cwd() / model_config_name
@@ -120,7 +137,7 @@ def main(model_name: str, model_version: str, model_task: str, user_config: str 
                 f"  Route 2 (registry default): no params defined for this model\n"
                 f"  Route 3 (registry config_path): '{model_config_location}' is not accessible"
             )
-        model_config_name = model_version_slug + "_" + model_task + "_config.yml"
+        model_config_name = model_version_slug + "_" + model_task + f"_config_{config_stem(model_config_location)}.yml"
         write_meta(
             "model_config_meta.json", model_config_name, model_config_location, config_location_type
         )


### PR DESCRIPTION
The storeDir usage was too generous, resulting in cache hits for `downloadArtefact` for the model config when the actual underlying config had changed. I've added a hashing tag too this.

Note I see this as a semi-temporary fix. The mixed handling of user parameter and non-user/model-specific configs, and finetuning, may require a smarter redesign of this part. For now, however, this works and fixes things, with some potential future cost and another potentially confusing creation of more (albeit tiny) files in the cache. Oh, and another hash!