### PR TITLE
AIOD-336 ome zarr out

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -117,7 +117,7 @@ log.info """\
 
 // Function to get the name of the mask file given the image and model-version-task
 def getMaskName(img_file, resolvedParamHash) {
-    return "${img_file.simpleName}" + "_masks_" + "${params.task}-${params.model}-${params.model_type}-${resolvedParamHash}"
+    return "${img_file.name}" + "_masks_" + "${params.task}-${params.model}-${params.model_type}-${resolvedParamHash}"
 }
 
 // NOTE: Name this workflow when finetuning is implemented for multiple workflows

--- a/main.nf
+++ b/main.nf
@@ -117,7 +117,7 @@ log.info """\
 
 // Function to get the name of the mask file given the image and model-version-task
 def getMaskName(img_file, resolvedParamHash) {
-    return "${img_file.baseName}" + "_masks_" + "${params.task}-${params.model}-${params.model_type}-${resolvedParamHash}"
+    return "${img_file.simpleName}" + "_masks_" + "${params.task}-${params.model}-${params.model_type}-${resolvedParamHash}"
 }
 
 // NOTE: Name this workflow when finetuning is implemented for multiple workflows

--- a/modules/models/main.nf
+++ b/modules/models/main.nf
@@ -10,7 +10,7 @@ process preprocessImage {
 
     output:
     path "${image_path.simpleName}.csv", emit: img_csv
-    path "${image_path.simpleName}_*.${image_path.extension}", emit: prep_imgs
+    path "${image_path.simpleName}_*.{${image_path.extension},ome.zarr}", emit: prep_imgs
 
     script:
     """

--- a/modules/models/main.nf
+++ b/modules/models/main.nf
@@ -9,8 +9,8 @@ process preprocessImage {
     path img_csv
 
     output:
-    path "${image_path.simpleName}.csv", emit: img_csv
-    path "${image_path.simpleName}_*.{${image_path.extension},ome.zarr}", emit: prep_imgs
+    path "${image_path.name}.csv", emit: img_csv
+    path "${image_path.name}_*.ome.zarr", emit: prep_imgs
 
     script:
     """
@@ -128,7 +128,7 @@ process runModel {
     val output_mask_type
 
     output:
-    tuple val("${image_path.baseName}"), val(meta), val(mask_fname), val(mask_output_dir), path("${mask_fname}_x${idxs[0]}-${idxs[1]}_y${idxs[2]}-${idxs[3]}_z${idxs[4]}-${idxs[5]}.rle"), emit: mask
+    tuple val("${image_path.name}"), val(meta), val(mask_fname), val(mask_output_dir), path("${mask_fname}_x${idxs[0]}-${idxs[1]}_y${idxs[2]}-${idxs[3]}_z${idxs[4]}-${idxs[5]}.rle"), emit: mask
 
     script:
     """

--- a/modules/models/resources/usr/bin/preprocess_image.py
+++ b/modules/models/resources/usr/bin/preprocess_image.py
@@ -15,18 +15,15 @@ DIM_ORDER = 'CZYX'
 
 def construct_fname(img_path, preprocess_params):
     suffix = get_params_str(preprocess_params, to_save=True)
-    img_path = Path(img_path)
-    return Path(f"{img_path.stem}_{suffix}{img_path.suffix}")
+    # Preserve full original filename (including extension) to avoid
+    # Nextflow simpleName stripping dots in param values (e.g. clipLimit=3.0).
+    # Always output as OME-Zarr for intermediates.
+    return Path(f"{Path(img_path).name}_{suffix}.ome.zarr")
 
 
 def save_preprocessed_image(img_path, preprocess_params, prep_image, save_dims):
     fname = construct_fname(img_path, preprocess_params)
-    # Save the image in the original format if possible, else OME-Zarr.
-    # save_dims matches the squeezed data shape; BioImage expands back to CZYX on load.
-    try:
-        save_image(prep_image, fname, dim_order=save_dims)
-    except (ValueError, KeyError):
-        save_image(prep_image, fname := fname.with_suffix(".ome.zarr"), dim_order=save_dims)
+    save_image(prep_image, fname, dim_order=save_dims)
     return fname
 
 
@@ -95,4 +92,4 @@ if __name__ == "__main__":
             df_new.loc[i, "height"] = new_height
             df_new.loc[i, "width"] = new_width
     # Save the new dataframe
-    df_new.to_csv(f"{Path(args.img_path).stem}.csv", index=False)
+    df_new.to_csv(f"{Path(args.img_path).name}.csv", index=False)

--- a/modules/models/resources/usr/bin/preprocess_image.py
+++ b/modules/models/resources/usr/bin/preprocess_image.py
@@ -8,9 +8,7 @@ import numpy as np
 import pandas as pd
 from aiod_utils.io import load_image_data, save_image
 from aiod_utils.preprocess import get_params_str, load_methods, run_preprocess
-
-
-DIM_ORDER = 'CZYX'
+from utils import DEFAULT_DIM_ORDER as DIM_ORDER
 
 
 def construct_fname(img_path, preprocess_params):

--- a/modules/models/resources/usr/bin/preprocess_image.py
+++ b/modules/models/resources/usr/bin/preprocess_image.py
@@ -10,19 +10,23 @@ from aiod_utils.io import load_image_data, save_image
 from aiod_utils.preprocess import get_params_str, load_methods, run_preprocess
 
 
+DIM_ORDER = 'CZYX'
+
+
 def construct_fname(img_path, preprocess_params):
     suffix = get_params_str(preprocess_params, to_save=True)
     img_path = Path(img_path)
     return Path(f"{img_path.stem}_{suffix}{img_path.suffix}")
 
 
-def save_preprocessed_image(img_path, preprocess_params, prep_image):
+def save_preprocessed_image(img_path, preprocess_params, prep_image, save_dims):
     fname = construct_fname(img_path, preprocess_params)
-    # Save the image in the original format if possible, else OME-Zarr
+    # Save the image in the original format if possible, else OME-Zarr.
+    # save_dims matches the squeezed data shape; BioImage expands back to CZYX on load.
     try:
-        save_image(prep_image, fname)
+        save_image(prep_image, fname, dim_order=save_dims)
     except (ValueError, KeyError):
-        save_image(prep_image, fname := fname.with_suffix(".ome.zarr"))
+        save_image(prep_image, fname := fname.with_suffix(".ome.zarr"), dim_order=save_dims)
     return fname
 
 
@@ -53,7 +57,7 @@ if __name__ == "__main__":
     # TODO: Switch to return_dask, map over blocks, and check output as described at top
     # Load with explicit CZYX ordering so axis identity is preserved for all image types,
     # including RGB images where the S (samples) dimension is mapped to C, giving (C, Z, H, W).
-    image_4d = load_image_data(args.img_path, dim_order="CZYX")
+    image_4d = load_image_data(args.img_path, dim_order=DIM_ORDER)
     # Record which axes are singleton before squeezing so we can reconstruct CZYX afterwards
     squeezed_axes = [i for i, s in enumerate(image_4d.shape) if s == 1]
     image = image_4d.squeeze()
@@ -62,6 +66,8 @@ if __name__ == "__main__":
     # Create a new dataframe to store the new images, repeating rows per preprocessing set
     df_new = pd.concat([df_img.copy()] * len(preprocess_methods), ignore_index=True)
     # Loop over each set and preprocess
+    # Derive the dim_order that matches the squeezed data
+    save_dims = "".join(d for i, d in enumerate(DIM_ORDER) if i not in squeezed_axes)
     for i, preprocess_dict in enumerate(preprocess_methods):
         prep_image = run_preprocess(image, methods=preprocess_dict, parse=False)
         # Get the new filename with embedded preprocessing params
@@ -69,6 +75,7 @@ if __name__ == "__main__":
             img_path=args.img_path,
             preprocess_params=preprocess_dict,
             prep_image=prep_image,
+            save_dims=save_dims,
         )
         # Update the dataframe with the new image path, ensuring full path given
         df_new.loc[i, "img_path"] = fname

--- a/modules/models/resources/usr/bin/preprocess_image.py
+++ b/modules/models/resources/usr/bin/preprocess_image.py
@@ -6,22 +6,23 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-import skimage.io
-from aiod_utils.io import load_image_data
+from aiod_utils.io import load_image_data, save_image
 from aiod_utils.preprocess import get_params_str, load_methods, run_preprocess
 
 
 def construct_fname(img_path, preprocess_params):
     suffix = get_params_str(preprocess_params, to_save=True)
     img_path = Path(img_path)
-    return f"{img_path.stem}_{suffix}{img_path.suffix}"
+    return Path(f"{img_path.stem}_{suffix}{img_path.suffix}")
 
 
 def save_preprocessed_image(img_path, preprocess_params, prep_image):
     fname = construct_fname(img_path, preprocess_params)
-    # Save the image
-    # TODO: Switch over to bioio when fully sorted, standardising to OME-TIFF internally within Segment-Flow
-    skimage.io.imsave(fname, prep_image)
+    # Save the image in the original format if possible, else OME-Zarr
+    try:
+        save_image(prep_image, fname)
+    except (ValueError, KeyError):
+        save_image(prep_image, fname := fname.with_suffix(".ome.zarr"))
     return fname
 
 

--- a/modules/models/resources/usr/bin/run_panseg.py
+++ b/modules/models/resources/usr/bin/run_panseg.py
@@ -111,36 +111,25 @@ if __name__ == "__main__":
     with open(cli_args.model_config) as f:
         config = yaml.safe_load(f)
 
+    # Determine input layout based on image shape
+    # Since load_img always returns CZYX format, we need to handle the layout accordingly
+    if cli_args.num_slices > 1:
+        # 3D data
+        # Squeeze channel dimension for single channel 3D data
+        input_layout = "ZYX" if cli_args.channels == 1 else "CZYX"
+    else:
+        # 2D data
+        # Squeeze both channel and z dimensions for single channel 2D data
+        input_layout = "YX" if cli_args.channels == 1 else "CYX"
+
     # Load image and apply preprocessing if specified
     img = load_img(
         fpath=cli_args.img_path,
         idxs=cli_args.idxs,
         channels=cli_args.channels,
         num_slices=cli_args.num_slices,
-        dim_order="CZYX",
+        dim_order=input_layout,
     )
-
-    # Determine input layout based on image shape
-    # Since load_img always returns CZYX format, we need to handle the layout accordingly
-    if cli_args.num_slices > 1:
-        # 3D data
-        if cli_args.channels == 1:
-            # Squeeze channel dimension for single channel 3D data
-            img = img[0]  # Remove the channel dimension
-            input_layout = "ZYX"
-        else:
-            # Multi-channel 3D data
-            input_layout = "CZYX"
-    else:
-        # 2D data
-        if cli_args.channels == 1:
-            # Squeeze both channel and z dimensions for single channel 2D data
-            img = img[0, 0]  # Remove channel and z dimensions
-            input_layout = "YX"
-        else:
-            # Multi-channel 2D data
-            img = img[:, 0, :, :]  # Remove z dimension but keep channels
-            input_layout = "CYX"
 
     config["input_layout"] = input_layout
 

--- a/modules/models/resources/usr/bin/utils.py
+++ b/modules/models/resources/usr/bin/utils.py
@@ -8,6 +8,8 @@ import aiod_utils.rle as aiod_rle
 import numpy as np
 from skimage.segmentation import relabel_sequential
 
+DEFAULT_DIM_ORDER = "CZYX"
+
 
 def save_masks(
     save_dir,
@@ -84,10 +86,9 @@ def load_img(
     idxs: list[int, ...],
     channels: int | None = None,
     num_slices: int | None = None,
+    dim_order: str = DEFAULT_DIM_ORDER,
     **kwargs,
 ):
-    # Caller should specify desired dimension ordering (model dependent)
-    dim_order = kwargs.pop("dim_order", "CZYX")
     # TODO: Better to return Dask and index as needed?
     # NOTE: here rbg converted to channels; napari treats rbg separately
     img = aiod_io.load_image_data(


### PR DESCRIPTION
fixes AIOD-321
fixes AIOD-336

- all preprocessing files written to .ome.zarr
- all derivatives append to original filenames without stripping extensions

requires FrancisCrickInstitute/aiod_utils#13 and https://github.com/FrancisCrickInstitute/aiod_napari/pull/44