### PR TITLE
AIOD-336: Centralised Naming Integration

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -115,15 +115,14 @@ log.info """\
          """.stripIndent()
 
 
-// Mirrors aiod_utils.io.get_mask_name() - keep both in sync if this changes.
-// Deliberately opaque (no task/model/model_type): resolvedParamHash already
-// covers them for uniqueness, and they're visible in the relevant model dir
+// NOTE: Mirrors aiod_utils.io.get_mask_name() - keep both in sync if this changes.
+// resolvedParamHash encodes all relevant params to ensure uniqueness
 def getMaskName(image_id, prep_hash, resolvedParamHash) {
     def prep_suffix = prep_hash ? "_${prep_hash}" : ""
     return "${image_id}${prep_suffix}_masks_${resolvedParamHash}"
 }
 
-// NOTE: Name this workflow when finetuning is implemented for multiple workflows
+// TODO: Name this workflow when finetuning is implemented for multiple workflows
 workflow {
     // Dynamically discover available models by scanning for run_<model>.py files
     def modelScriptsDir = file("${workflow.projectDir}/modules/models/resources/usr/bin")
@@ -141,18 +140,12 @@ workflow {
     )
 
     // Parse each registry metadata JSON into a (name, location, type) tuple and
-    // call downloadArtifact once per artifact. Each call has a single mandatory
-    // output, so storeDir's cache check is always unambiguous. The optional
-    // channels from setupModel act as natural gates: if a model has no config,
-    // setupModel.out.model_config_meta emits nothing and downloadArtifact is
-    // never scheduled for it.
+    // call downloadArtifact once per artifact (if present)
     def parseMeta = { label, meta_file ->
         def m = new groovy.json.JsonSlurper().parse(meta_file)
         tuple(label, m.name, m.location, m.type)
     }
 
-    // Merge all artifact metadata into one channel so downloadArtifact is only
-    // called once — DSL2 does not allow reusing a process in the same workflow.
     // The label ('checkpoint', 'config', 'finetuning') is carried through as a
     // val so we can filter the mixed output channel downstream.
     downloadArtifact(

--- a/main.nf
+++ b/main.nf
@@ -174,12 +174,9 @@ workflow {
         | map    { _label, file -> file }
         | first()
 
-    // Add a stable image_id (and placeholder prep_hash/preprocess_params)
-    // to every row up front. image_id relies on Python-side (bioio)
-    // extension recognition that Groovy cannot replicate, so every later
-    // naming decision reads it from here rather than re-deriving it —
-    // including the no-op/non-preprocessing paths below, which never run
-    // through preprocessImage at all.
+    // Add an image_id (and placeholder prep_hash) to every row
+    // image_id relies on Python-side (bioio) extension recognition that Groovy cannot replicate
+    // So compute it here and carry it forward
     computeImageIds( file(params.img_dir) )
     normalized_img_dir = computeImageIds.out.csv
 
@@ -187,7 +184,8 @@ workflow {
         // Split the CSV into individual images, so we preprocessImage distributes over each source image
         normalized_img_dir.splitCsv( header: true, quote: '\"' )
             | map{ row ->
-                meta = row.subMap("height", "width", "num_slices", "channels")
+                // image_id is needed by preprocessImage's own output glob
+                meta = row.subMap("height", "width", "num_slices", "channels", "image_id")
                 [
                     meta,
                     file(row.img_path),
@@ -213,10 +211,7 @@ workflow {
                 | mix(prep_img_names)
                 | set { img_names }
             all_img_info
-                // normalized_img_dir already shares all_img_info's column
-                // schema (image_id/prep_hash/preprocess_params included),
-                // so this merge stays schema-consistent unlike mixing in
-                // the raw, unaugmented img_dir CSV directly.
+                // normalized_img_dir shares all_img_info's columns
                 | mix(normalized_img_dir)
                 | collectFile(name: "all_img_info.csv", keepHeader: true)
                 | set { all_img_info }
@@ -238,7 +233,8 @@ workflow {
     // To then distribute to the model
     img_ch = splitStacks.out.csv_file.splitCsv( header: true, quote: '\"' )
         | map{ row ->
-            meta = row.subMap("height", "width", "num_slices", "channels", "preprocess_params")
+            // Reminder: resolvedParamHash is unique per run, and prep_hash unique per preprocessing branch, and image_id obvs unique per image
+            meta = row.subMap("height", "width", "num_slices", "channels", "prep_hash")
             [
                 row.img_path,
                 meta,
@@ -269,15 +265,16 @@ workflow {
         params.output_mask_type.toLowerCase()
     ).mask
 
-    // Group all the outputs per image together to combine
+    // Group all the substacks per image+branch together to combine.
+    // mask_fname (image_id-based) is the canonical identity to group on
+    // (as it is image+preprocessing-specific)
     mask_out
     | groupTuple
-    | map{ img_name, meta, mask_fnames, output_dirs, mask_paths ->
+    | map{ mask_fname, meta, output_dirs, mask_paths ->
         [
-            img_name,
+            mask_fname,
             meta.first(),
             params.model,
-            mask_fnames.first(),
             output_dirs.first(),
             mask_paths,
         ]

--- a/main.nf
+++ b/main.nf
@@ -88,7 +88,7 @@ def model_chkpt_dir     = "${model_dir}/checkpoints"
 params.model_chkpt_dir  = model_chkpt_dir  // needed by storeDir in modules
 
 // Import processes from model modules
-include { setupModel; downloadArtifact; preprocessImage; splitStacks; runModel; combineStacks } from './modules/models'
+include { setupModel; downloadArtifact; computeImageIds; preprocessImage; splitStacks; runModel; combineStacks } from './modules/models'
 
 def log_timestamp = new java.util.Date().format( 'yyyy-MM-dd HH:mm:ss' )
 
@@ -115,9 +115,14 @@ log.info """\
          """.stripIndent()
 
 
-// Function to get the name of the mask file given the image and model-version-task
-def getMaskName(img_file, resolvedParamHash) {
-    return "${img_file.name}" + "_masks_" + "${params.task}-${params.model}-${params.model_type}-${resolvedParamHash}"
+// Function to get the name of the mask file given an image's stable identity,
+// its preprocessing branch hash (empty string if no preprocessing applied),
+// and the whole-run param hash. Built purely from plain string fields —
+// never from a prior artifact's own filename — so no accessor here can ever
+// mis-parse an accumulated or compound extension.
+def getMaskName(image_id, prep_hash, resolvedParamHash) {
+    def prep_suffix = prep_hash ? "_${prep_hash}" : ""
+    return "${image_id}${prep_suffix}_masks_${params.task}-${params.model}-${params.model_type}-${resolvedParamHash}"
 }
 
 // NOTE: Name this workflow when finetuning is implemented for multiple workflows
@@ -171,21 +176,30 @@ workflow {
         | map    { _label, file -> file }
         | first()
 
+    // Add a stable image_id (and placeholder prep_hash/preprocess_params)
+    // to every row up front. image_id relies on Python-side (bioio)
+    // extension recognition that Groovy cannot replicate, so every later
+    // naming decision reads it from here rather than re-deriving it —
+    // including the no-op/non-preprocessing paths below, which never run
+    // through preprocessImage at all.
+    computeImageIds( file(params.img_dir) )
+    normalized_img_dir = computeImageIds.out.csv
+
     if ( params.preprocess ) {
         // Split the CSV into individual images, so we preprocessImage distributes over each source image
-        channel.fromPath(params.img_dir).splitCsv( header: true, quote: '\"' )
+        normalized_img_dir.splitCsv( header: true, quote: '\"' )
             | map{ row ->
                 meta = row.subMap("height", "width", "num_slices", "channels")
                 [
                     meta,
                     file(row.img_path),
-                    getMaskName( file(row.img_path), resolvedParamHash ),
+                    "", // mask_fname: unused by preprocessImage's script
                 ]
             }
             | set { img_ch1 }
         // Preprocess the images, outputting one per non-empty preprocess set
         // Empty sets (i.e. no-ops) are mixed in later so no copies are made
-        preprocessImage( img_ch1, file(params.img_dir) )
+        preprocessImage( img_ch1, normalized_img_dir )
         preprocessImage.out.prep_imgs
             | flatten()
             | map{ img -> [img.name, img] }
@@ -196,12 +210,16 @@ workflow {
             | set { all_img_info }
         // Check for presence of any no-op sets & integrate if so
         if ( params.preprocess.any { it instanceof List && it.isEmpty() } ) {
-            channel.fromPath(params.img_dir).splitCsv( header: true, quote: '\"' )
+            normalized_img_dir.splitCsv( header: true, quote: '\"' )
                 | map{ row -> [row.img_path, file(row.img_path)] }
                 | mix(prep_img_names)
                 | set { img_names }
             all_img_info
-                | mix(channel.fromPath(params.img_dir))
+                // normalized_img_dir already shares all_img_info's column
+                // schema (image_id/prep_hash/preprocess_params included),
+                // so this merge stays schema-consistent unlike mixing in
+                // the raw, unaugmented img_dir CSV directly.
+                | mix(normalized_img_dir)
                 | collectFile(name: "all_img_info.csv", keepHeader: true)
                 | set { all_img_info }
         } else {
@@ -212,21 +230,21 @@ workflow {
     }
     // If not preprocessing, just split the stacks using the original CSV
     else {
-        channel.fromPath(params.img_dir).splitCsv( header: true, quote: '\"' )
+        normalized_img_dir.splitCsv( header: true, quote: '\"' )
             | map{ row -> [row.img_path, file(row.img_path)]}
             | set { img_names }
-        splitStacks( file(params.img_dir), chkpt_ch )
+        splitStacks( normalized_img_dir, chkpt_ch )
     }
 
     // Now prepare each substack for each (poss preprocessed) image
     // To then distribute to the model
     img_ch = splitStacks.out.csv_file.splitCsv( header: true, quote: '\"' )
         | map{ row ->
-            meta = row.subMap("height", "width", "num_slices", "channels")
+            meta = row.subMap("height", "width", "num_slices", "channels", "preprocess_params")
             [
                 row.img_path,
                 meta,
-                getMaskName( file( row.img_path ), resolvedParamHash ),
+                getMaskName( row.image_id, row.prep_hash, resolvedParamHash ),
                 [
                     row.start_w.toInteger(),
                     row.end_w.toInteger(),

--- a/main.nf
+++ b/main.nf
@@ -115,14 +115,12 @@ log.info """\
          """.stripIndent()
 
 
-// Function to get the name of the mask file given an image's stable identity,
-// its preprocessing branch hash (empty string if no preprocessing applied),
-// and the whole-run param hash. Built purely from plain string fields —
-// never from a prior artifact's own filename — so no accessor here can ever
-// mis-parse an accumulated or compound extension.
+// Mirrors aiod_utils.io.get_mask_name() - keep both in sync if this changes.
+// Deliberately opaque (no task/model/model_type): resolvedParamHash already
+// covers them for uniqueness, and they're visible in the relevant model dir
 def getMaskName(image_id, prep_hash, resolvedParamHash) {
     def prep_suffix = prep_hash ? "_${prep_hash}" : ""
-    return "${image_id}${prep_suffix}_masks_${params.task}-${params.model}-${params.model_type}-${resolvedParamHash}"
+    return "${image_id}${prep_suffix}_masks_${resolvedParamHash}"
 }
 
 // NOTE: Name this workflow when finetuning is implemented for multiple workflows

--- a/main.nf
+++ b/main.nf
@@ -197,6 +197,11 @@ workflow {
         preprocessImage.out.img_csv
             | collectFile(name: "all_img_info.csv", keepHeader: true)
             | set { all_img_info }
+        // Grab the hashes and associated prep sets and log for info
+        preprocessImage.out.hash_legend
+            | first()
+            | map { it.text }
+            | subscribe { legend -> log.info "\nPreprocessing hash legend for this run:\n${legend}" }
         // Check for presence of any no-op sets & integrate if so
         if ( params.preprocess.any { it instanceof List && it.isEmpty() } ) {
             normalized_img_dir.splitCsv( header: true, quote: '\"' )

--- a/modules/models/main.nf
+++ b/modules/models/main.nf
@@ -33,6 +33,8 @@ process preprocessImage {
     // preprocess_image.py names both outputs by image_id
     path "${meta.image_id}.csv", emit: img_csv
     path "${meta.image_id}_*.ome.zarr", emit: prep_imgs
+    // Log prep hashes and associated sets
+    path "preprocess_hashes.txt", emit: hash_legend
 
     script:
     """

--- a/modules/models/main.nf
+++ b/modules/models/main.nf
@@ -1,6 +1,6 @@
 process computeImageIds {
     // Adds a stable image_id (plus a placeholder prep_hash) to every row of
-    // the image CSV before any preprocessing branching.
+    // the image CSV before any preprocessing branching
     conda "${moduleDir}/envs/conda_combine_stacks.yml"
     memory { 500.MB * task.attempt as MemoryUnit }
     time { 5.m * task.attempt }
@@ -30,8 +30,7 @@ process preprocessImage {
     path img_csv
 
     output:
-    // preprocess_image.py names both outputs by image_id (bioio-based
-    // extension stripping)
+    // preprocess_image.py names both outputs by image_id
     path "${meta.image_id}.csv", emit: img_csv
     path "${meta.image_id}_*.ome.zarr", emit: prep_imgs
 
@@ -78,14 +77,13 @@ process splitStacks {
 }
 
 process downloadArtifact {
-    // storeDir is the external model cache. Nextflow checks whether the output
+    // storeDir is the central AIoD cache. Nextflow checks whether the output
     // file already exists there before deciding to run this process:
     //   - Cache hit:  execution is skipped; the existing file is symlinked into
-    //                 the task work directory (reversing the usual publishDir flow).
+    //                 the task work directory
     //   - Cache miss: the script runs and the result is persisted to the store.
-    //
     // One process call per artifact means each has a single mandatory output, so
-    // storeDir's cache check is always unambiguous — no optional outputs needed.
+    // storeDir's cache check is always unambiguous (no optional outputs)
     conda "${moduleDir}/envs/conda_setup_model.yml"
     storeDir params.model_chkpt_dir
 
@@ -107,11 +105,7 @@ process downloadArtifact {
 process setupModel {
     // Queries the AIoD registry and writes one JSON metadata file per artifact
     // (checkpoint always present; config and finetuning only when the model has
-    // them). No downloading occurs here — that is handled by downloadArtifact.
-    // The optional outputs here are correct and safe: storeDir is not used on
-    // this process, so Nextflow never skips execution based on output existence.
-    // An absent config/finetuning simply means the script didn't write that file,
-    // and the optional channel emits nothing — which is the intended behaviour.
+    // them, i.e. nothing is emitted)
     conda "${moduleDir}/envs/conda_setup_model.yml"
 
     input:

--- a/modules/models/main.nf
+++ b/modules/models/main.nf
@@ -1,9 +1,6 @@
 process computeImageIds {
-    // Adds a stable image_id (plus placeholder prep_hash/preprocess_params)
-    // to every row of the image CSV before any preprocessing branching.
-    // image_id depends on aiod_utils' bioio-based extension recognition,
-    // which Groovy cannot replicate, so every downstream naming decision
-    // reads it from here rather than re-deriving it independently.
+    // Adds a stable image_id (plus a placeholder prep_hash) to every row of
+    // the image CSV before any preprocessing branching.
     conda "${moduleDir}/envs/conda_combine_stacks.yml"
     memory { 500.MB * task.attempt as MemoryUnit }
     time { 5.m * task.attempt }
@@ -33,8 +30,10 @@ process preprocessImage {
     path img_csv
 
     output:
-    path "${image_path.name}.csv", emit: img_csv
-    path "${image_path.name}_*.ome.zarr", emit: prep_imgs
+    // preprocess_image.py names both outputs by image_id (bioio-based
+    // extension stripping)
+    path "${meta.image_id}.csv", emit: img_csv
+    path "${meta.image_id}_*.ome.zarr", emit: prep_imgs
 
     script:
     """
@@ -144,7 +143,7 @@ process runModel {
     publishDir "$mask_output_dir"
 
     input:
-    tuple val(image_name), val(meta), val(mask_fname), val(idxs), path(image_path)
+    tuple val(img_path_key), val(meta), val(mask_fname), val(idxs), path(image_path)
     val mask_output_dir
     path model_config
     path model_chkpt
@@ -152,7 +151,8 @@ process runModel {
     val output_mask_type
 
     output:
-    tuple val("${image_path.name}"), val(meta), val(mask_fname), val(mask_output_dir), path("${mask_fname}_x${idxs[0]}-${idxs[1]}_y${idxs[2]}-${idxs[3]}_z${idxs[4]}-${idxs[5]}.rle"), emit: mask
+    // Output mask_fname to uniquely group on image + preprocesing branch
+    tuple val(mask_fname), val(meta), val(mask_output_dir), path("${mask_fname}_x${idxs[0]}-${idxs[1]}_y${idxs[2]}-${idxs[3]}_z${idxs[4]}-${idxs[5]}.rle"), emit: mask
 
     script:
     """
@@ -180,7 +180,7 @@ process combineStacks {
     publishDir "$mask_output_dir", mode: 'copy'
 
     input:
-    tuple val(img_simplename), val(meta), val(model), val(mask_fname), val(mask_output_dir), path(masks, arity: '1..*')
+    tuple val(mask_fname), val(meta), val(model), val(mask_output_dir), path(masks, arity: '1..*')
     val postprocess
     val output_format
     val output_mask_type
@@ -191,8 +191,12 @@ process combineStacks {
     script:
     def postprocess = postprocess ? "--postprocess" : ""
     overlap = params.overlap.replace(",", " ")
+    // Same run-level preprocess config preprocessImage receives - combine_stacks.py
+    // matches meta.prep_hash against it to recover this branch's own preprocessing
+    // set, rather than threading the raw set itself through the CSV pipeline.
     """
     echo ${task.memory}
+    echo '${groovy.json.JsonOutput.toJson(params.preprocess)}' > preprocess_config.json
     python ${moduleDir}/resources/usr/bin/combine_stacks.py \
     --mask-fname "${mask_fname}" \
     --output-dir "${mask_output_dir}" \
@@ -203,7 +207,8 @@ process combineStacks {
     --iou-threshold ${params.iou_threshold} \
     --output-format ${output_format} \
     --output-mask-type ${output_mask_type} \
-    --preprocess-params '${meta.preprocess_params ?: "[]"}' \
+    --preprocess-config preprocess_config.json \
+    --prep-hash "${meta.prep_hash ?: ""}" \
     ${postprocess}
     """
 }

--- a/modules/models/main.nf
+++ b/modules/models/main.nf
@@ -1,3 +1,27 @@
+process computeImageIds {
+    // Adds a stable image_id (plus placeholder prep_hash/preprocess_params)
+    // to every row of the image CSV before any preprocessing branching.
+    // image_id depends on aiod_utils' bioio-based extension recognition,
+    // which Groovy cannot replicate, so every downstream naming decision
+    // reads it from here rather than re-deriving it independently.
+    conda "${moduleDir}/envs/conda_combine_stacks.yml"
+    memory { 500.MB * task.attempt as MemoryUnit }
+    time { 5.m * task.attempt }
+
+    input:
+    path img_csv
+
+    output:
+    path "with_ids_${img_csv}", emit: csv
+
+    script:
+    """
+    python ${moduleDir}/resources/usr/bin/add_image_ids.py \
+    --img-csv ${img_csv} \
+    --output-csv with_ids_${img_csv}
+    """
+}
+
 process preprocessImage {
     // Re-use the combine stacks conda env
     conda "${moduleDir}/envs/conda_combine_stacks.yml"
@@ -179,6 +203,7 @@ process combineStacks {
     --iou-threshold ${params.iou_threshold} \
     --output-format ${output_format} \
     --output-mask-type ${output_mask_type} \
+    --preprocess-params '${meta.preprocess_params ?: "[]"}' \
     ${postprocess}
     """
 }

--- a/modules/models/resources/usr/bin/add_image_ids.py
+++ b/modules/models/resources/usr/bin/add_image_ids.py
@@ -1,13 +1,13 @@
 """
-Adds a stable image_id (plus placeholder prep_hash/preprocess_params columns)
-to every row of the input image CSV, before any preprocessing branching
-happens. image_id relies on aiod_utils' bioio-based extension recognition,
-which Nextflow/Groovy cannot replicate natively, so it's computed once here
-in Python rather than re-derived independently wherever it's needed.
+Adds a stable image_id and prep_hash column to every row of
+the input image CSV, before any preprocessing branching happens.
 
-Preprocessed branches later overwrite prep_hash/preprocess_params with their
-real values (see preprocess_image.py); no-op/non-preprocessed rows keep the
-placeholders here, so every row in the pipeline shares the same CSV schema.
+image_id derived from aiod_utils' bioio-based extension recognition
+Necessary as we can't do this in Nextflow/Groovy!
+
+Preprocessed branches later overwrite prep_hash with its real value (see
+preprocess_image.py)
+Non-preprocessed rows keep placeholder so every row shares the same CSV cols
 """
 
 import argparse
@@ -30,6 +30,4 @@ if __name__ == "__main__":
     df["image_id"] = df["img_path"].apply(get_image_id)
     if "prep_hash" not in df.columns:
         df["prep_hash"] = ""
-    if "preprocess_params" not in df.columns:
-        df["preprocess_params"] = "[]"
     df.to_csv(Path(args.output_csv), index=False)

--- a/modules/models/resources/usr/bin/add_image_ids.py
+++ b/modules/models/resources/usr/bin/add_image_ids.py
@@ -5,6 +5,9 @@ the input image CSV, before any preprocessing branching happens.
 image_id derived from aiod_utils' bioio-based extension recognition
 Necessary as we can't do this in Nextflow/Groovy!
 
+resolve_image_ids() is run once over the whole run's image paths
+to handle collisions
+
 Preprocessed branches later overwrite prep_hash with its real value (see
 preprocess_image.py)
 Non-preprocessed rows keep placeholder so every row shares the same CSV cols
@@ -14,7 +17,7 @@ import argparse
 from pathlib import Path
 
 import pandas as pd
-from aiod_utils.io import get_image_id
+from aiod_utils.io import resolve_image_ids
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -27,7 +30,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     df = pd.read_csv(args.img_csv)
-    df["image_id"] = df["img_path"].apply(get_image_id)
+    df["image_id"] = resolve_image_ids(df["img_path"])
     if "prep_hash" not in df.columns:
         df["prep_hash"] = ""
     df.to_csv(Path(args.output_csv), index=False)

--- a/modules/models/resources/usr/bin/add_image_ids.py
+++ b/modules/models/resources/usr/bin/add_image_ids.py
@@ -1,0 +1,35 @@
+"""
+Adds a stable image_id (plus placeholder prep_hash/preprocess_params columns)
+to every row of the input image CSV, before any preprocessing branching
+happens. image_id relies on aiod_utils' bioio-based extension recognition,
+which Nextflow/Groovy cannot replicate natively, so it's computed once here
+in Python rather than re-derived independently wherever it's needed.
+
+Preprocessed branches later overwrite prep_hash/preprocess_params with their
+real values (see preprocess_image.py); no-op/non-preprocessed rows keep the
+placeholders here, so every row in the pipeline shares the same CSV schema.
+"""
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+from aiod_utils.io import get_image_id
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Add a stable image_id to every row of an image CSV"
+    )
+    parser.add_argument("--img-csv", required=True, help="Path to the input CSV")
+    parser.add_argument(
+        "--output-csv", required=True, help="Path to write the augmented CSV"
+    )
+    args = parser.parse_args()
+
+    df = pd.read_csv(args.img_csv)
+    df["image_id"] = df["img_path"].apply(get_image_id)
+    if "prep_hash" not in df.columns:
+        df["prep_hash"] = ""
+    if "preprocess_params" not in df.columns:
+        df["preprocess_params"] = "[]"
+    df.to_csv(Path(args.output_csv), index=False)

--- a/modules/models/resources/usr/bin/combine_stacks.py
+++ b/modules/models/resources/usr/bin/combine_stacks.py
@@ -1,3 +1,4 @@
+import json
 import os
 from pathlib import Path
 
@@ -346,6 +347,16 @@ if __name__ == "__main__":
         choices=["auto", "binary", "instance"],
         help="Mask type of the combined output ('binary' or 'instance')",
     )
+    parser.add_argument(
+        "--preprocess-params",
+        required=False,
+        default="[]",
+        help=(
+            "JSON-encoded list of preprocessing method dicts applied to this "
+            "image branch; used to recover e.g. the downsample factor for "
+            "output metadata without parsing it back out of the mask filename."
+        ),
+    )
 
     cli_args = parser.parse_args()
 
@@ -389,15 +400,21 @@ if __name__ == "__main__":
     # Save the masks
     output_format = cli_args.output_format.lower()
     save_path = f"{cli_args.mask_fname}_all.{output_format}"
-    # Get downsample factor for metadata if used
-    # NOTE: Our Napari plugin uses this as an identifier to rescale for visualization
-    # FIXME: This is brittle and poor, the params should be extracted from the preprocess params
-    # Which themselves should be tied to the image that they produced
-    if "Downsample" in cli_args.mask_fname:
-        downsample_factor = get_downsample_factor(filename=cli_args.mask_fname)
-        metadata = {"downsample_factor": downsample_factor}
-    else:
-        metadata = {}
+    # Get downsample factor for metadata if used.
+    # NOTE: Our Napari plugin uses this as an identifier to rescale for visualization.
+    # Read from the structured preprocess params passed through the pipeline's
+    # CSV/meta, rather than regexing the (now hashed) mask filename.
+    preprocess_methods = json.loads(cli_args.preprocess_params)
+    downsample_factor = (
+        get_downsample_factor(methods=preprocess_methods)
+        if preprocess_methods
+        else None
+    )
+    metadata = (
+        {"downsample_factor": downsample_factor}
+        if downsample_factor is not None
+        else {}
+    )
     if output_format == "tiff":
         # Resolve 'auto' using the mask type recorded in the individual patches
         resolved_mask_type = (

--- a/modules/models/resources/usr/bin/combine_stacks.py
+++ b/modules/models/resources/usr/bin/combine_stacks.py
@@ -1,4 +1,3 @@
-import json
 import os
 from pathlib import Path
 
@@ -10,12 +9,36 @@ import psutil
 import skimage.measure
 import tifffile
 from aiod_utils.io import extract_idxs_from_fname, reduce_dtype
-from aiod_utils.preprocess import get_downsample_factor
+from aiod_utils.preprocess import (
+    get_downsample_factor,
+    get_params_str,
+    hash_params_str,
+    load_methods,
+)
 from numba import jit, prange
 from numba.core import types
 from numba.typed import Dict
 from skimage.segmentation import relabel_sequential
 from tqdm import tqdm
+
+
+def get_preprocess_methods(config_path: str, prep_hash: str) -> list[dict]:
+    """
+    Find the specific preprocessing methods set matching prep_hash within the
+    run's full preprocessing config (params.preprocess). Matches by
+    recomputing the same hash used to create prep_hash in the first place
+    (see preprocess_image.py), rather than threading the set itself through
+    the pipeline's CSV, which can't safely carry raw JSON.
+    """
+    if not prep_hash:
+        return []
+    candidates = load_methods(config_path, filter_noop=True)
+    for methods in candidates:
+        if hash_params_str(get_params_str(methods, to_save=True)) == prep_hash:
+            return methods
+    raise ValueError(
+        f"No preprocessing set in {config_path} matches prep_hash '{prep_hash}'"
+    )
 
 
 def combine_masks(
@@ -348,14 +371,19 @@ if __name__ == "__main__":
         help="Mask type of the combined output ('binary' or 'instance')",
     )
     parser.add_argument(
-        "--preprocess-params",
-        required=False,
-        default="[]",
+        "--preprocess-config",
+        required=True,
         help=(
-            "JSON-encoded list of preprocessing method dicts applied to this "
-            "image branch; used to recover e.g. the downsample factor for "
-            "output metadata without parsing it back out of the mask filename."
+            "Path to a JSON file of the run's full params.preprocess config "
+            "(same file preprocessImage receives); used with --prep-hash to "
+            "recover e.g. the downsample factor for output metadata."
         ),
+    )
+    parser.add_argument(
+        "--prep-hash",
+        required=False,
+        default="",
+        help="Hash identifying this image's preprocessing branch, empty if none",
     )
 
     cli_args = parser.parse_args()
@@ -402,9 +430,11 @@ if __name__ == "__main__":
     save_path = f"{cli_args.mask_fname}_all.{output_format}"
     # Get downsample factor for metadata if used.
     # NOTE: Our Napari plugin uses this as an identifier to rescale for visualization.
-    # Read from the structured preprocess params passed through the pipeline's
-    # CSV/meta, rather than regexing the (now hashed) mask filename.
-    preprocess_methods = json.loads(cli_args.preprocess_params)
+    # Recover this branch's preprocessing set from the run's full config by
+    # matching prep_hash, rather than regexing out of the hashed mask fname
+    preprocess_methods = get_preprocess_methods(
+        cli_args.preprocess_config, cli_args.prep_hash
+    )
     downsample_factor = (
         get_downsample_factor(methods=preprocess_methods)
         if preprocess_methods

--- a/modules/models/resources/usr/bin/combine_stacks.py
+++ b/modules/models/resources/usr/bin/combine_stacks.py
@@ -429,9 +429,9 @@ if __name__ == "__main__":
     output_format = cli_args.output_format.lower()
     save_path = f"{cli_args.mask_fname}_all.{output_format}"
     # Get downsample factor for metadata if used.
-    # NOTE: Our Napari plugin uses this as an identifier to rescale for visualization.
+    # NOTE: Our Napari plugin uses this as an identifier to rescale for visualization
     # Recover this branch's preprocessing set from the run's full config by
-    # matching prep_hash, rather than regexing out of the hashed mask fname
+    # matching prep_hash
     preprocess_methods = get_preprocess_methods(
         cli_args.preprocess_config, cli_args.prep_hash
     )

--- a/modules/models/resources/usr/bin/preprocess_image.py
+++ b/modules/models/resources/usr/bin/preprocess_image.py
@@ -2,7 +2,6 @@
 For this first version, where we will implement this new pipeline for preprocessing sets, we will just use the existing functions and run them over the whole image naively without Dask/chunk thoughts
 """
 
-import json
 from pathlib import Path
 
 import numpy as np
@@ -93,12 +92,11 @@ if __name__ == "__main__":
         # naming (getMaskName) never has to re-derive identity from a
         # filename, or recompute a hash that must stay bit-for-bit
         # consistent with what aiod_napari independently predicts.
-        # preprocess_params is the structured provenance for this branch,
-        # needed by combine_stacks.py to recover e.g. the downsample factor
-        # without regexing it back out of an (now hashed) filename.
+        # prep_hash also lets combine_stacks.py recover this branch's full
+        # preprocessing config later by matching it back against
+        # params.preprocess, rather than regexing it out of a filename.
         df_new.loc[i, "image_id"] = image_id
         df_new.loc[i, "prep_hash"] = hash_params_str(params_str)
-        df_new.loc[i, "preprocess_params"] = json.dumps(preprocess_dict)
         # Update shape info in the dataframe if downsampled/modified
         if image.shape != prep_image.shape:
             # Re-insert the singleton axes that were squeezed out to restore CZYX identity.
@@ -114,5 +112,5 @@ if __name__ == "__main__":
             df_new.loc[i, "num_slices"] = new_slices
             df_new.loc[i, "height"] = new_height
             df_new.loc[i, "width"] = new_width
-    # Save the new dataframe
-    df_new.to_csv(f"{Path(args.img_path).name}.csv", index=False)
+    # Save the new dataframe, matching the img_csv glob in modules/models/main.nf
+    df_new.to_csv(f"{image_id}.csv", index=False)

--- a/modules/models/resources/usr/bin/preprocess_image.py
+++ b/modules/models/resources/usr/bin/preprocess_image.py
@@ -75,9 +75,12 @@ if __name__ == "__main__":
     save_dims = "".join(d for i, d in enumerate(DIM_ORDER) if i not in squeezed_axes)
     # Retrieve image_id for naming
     image_id = df_img["image_id"].iloc[0]
+    # Container to store the hash with the preprocessing params for logging
+    legend_lines = []
     for i, preprocess_dict in enumerate(preprocess_methods):
         prep_image = run_preprocess(image, methods=preprocess_dict, parse=False)
         params_str = get_params_str(preprocess_dict, to_save=True)
+        prep_hash = hash_params_str(params_str)
         # Get the new filename, identified by a short hash of the params
         fname = save_preprocessed_image(
             image_id=image_id,
@@ -89,7 +92,10 @@ if __name__ == "__main__":
         df_new.loc[i, "img_path"] = fname
         # Embed image_id/prep_hash to use throughout for branching etc.
         df_new.loc[i, "image_id"] = image_id
-        df_new.loc[i, "prep_hash"] = hash_params_str(params_str)
+        df_new.loc[i, "prep_hash"] = prep_hash
+        legend_lines.append(
+            f"[{prep_hash}] {get_params_str(preprocess_dict, to_save=False)}"
+        )
         # Update shape info in the dataframe if downsampled/modified
         if image.shape != prep_image.shape:
             # Re-insert the singleton axes that were squeezed out to restore CZYX identity.
@@ -107,3 +113,7 @@ if __name__ == "__main__":
             df_new.loc[i, "width"] = new_width
     # Save the new dataframe, matching the img_csv glob in modules/models/main.nf
     df_new.to_csv(f"{image_id}.csv", index=False)
+    # Write the hashes to a file so we can log it with Nextflow instead of printing
+    # NOTE: I thought logging with Nxf would avoid stdout eating, ensures
+    # it's in the nextflow.log and not reliant on debug=true
+    Path("preprocess_hashes.txt").write_text("\n".join(legend_lines) + "\n")

--- a/modules/models/resources/usr/bin/preprocess_image.py
+++ b/modules/models/resources/usr/bin/preprocess_image.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-from aiod_utils.io import get_image_id, load_image_data, save_image
+from aiod_utils.io import load_image_data, save_image
 from aiod_utils.preprocess import (
     get_params_str,
     hash_params_str,
@@ -16,8 +16,7 @@ from aiod_utils.preprocess import (
 from utils import DEFAULT_DIM_ORDER as DIM_ORDER
 
 
-def construct_fname(img_path, params_str):
-    image_id = get_image_id(img_path)
+def construct_fname(image_id, params_str):
     param_hash = hash_params_str(params_str)
     # image_id + a short hash of the preprocessing params (not the raw
     # string) keeps names short and stops them accumulating a fresh
@@ -25,8 +24,8 @@ def construct_fname(img_path, params_str):
     return Path(f"{image_id}_{param_hash}.ome.zarr")
 
 
-def save_preprocessed_image(img_path, params_str, prep_image, save_dims):
-    fname = construct_fname(img_path, params_str)
+def save_preprocessed_image(image_id, params_str, prep_image, save_dims):
+    fname = construct_fname(image_id, params_str)
     save_image(prep_image, fname, dim_order=save_dims)
     return fname
 
@@ -74,27 +73,21 @@ if __name__ == "__main__":
     # Loop over each set and preprocess
     # Derive the dim_order that matches the squeezed data
     save_dims = "".join(d for i, d in enumerate(DIM_ORDER) if i not in squeezed_axes)
-    # Stable identity for the source image, independent of preprocessing branch
-    image_id = get_image_id(args.img_path)
+    # Retrieve image_id for naming
+    image_id = df_img["image_id"].iloc[0]
     for i, preprocess_dict in enumerate(preprocess_methods):
         prep_image = run_preprocess(image, methods=preprocess_dict, parse=False)
         params_str = get_params_str(preprocess_dict, to_save=True)
         # Get the new filename, identified by a short hash of the params
         fname = save_preprocessed_image(
-            img_path=args.img_path,
+            image_id=image_id,
             params_str=params_str,
             prep_image=prep_image,
             save_dims=save_dims,
         )
         # Update the dataframe with the new image path, ensuring full path given
         df_new.loc[i, "img_path"] = fname
-        # image_id/prep_hash travel onward as plain fields so downstream
-        # naming (getMaskName) never has to re-derive identity from a
-        # filename, or recompute a hash that must stay bit-for-bit
-        # consistent with what aiod_napari independently predicts.
-        # prep_hash also lets combine_stacks.py recover this branch's full
-        # preprocessing config later by matching it back against
-        # params.preprocess, rather than regexing it out of a filename.
+        # Embed image_id/prep_hash to use throughout for branching etc.
         df_new.loc[i, "image_id"] = image_id
         df_new.loc[i, "prep_hash"] = hash_params_str(params_str)
         # Update shape info in the dataframe if downsampled/modified

--- a/modules/models/resources/usr/bin/preprocess_image.py
+++ b/modules/models/resources/usr/bin/preprocess_image.py
@@ -2,25 +2,32 @@
 For this first version, where we will implement this new pipeline for preprocessing sets, we will just use the existing functions and run them over the whole image naively without Dask/chunk thoughts
 """
 
+import json
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
-from aiod_utils.io import load_image_data, save_image
-from aiod_utils.preprocess import get_params_str, load_methods, run_preprocess
+from aiod_utils.io import get_image_id, load_image_data, save_image
+from aiod_utils.preprocess import (
+    get_params_str,
+    hash_params_str,
+    load_methods,
+    run_preprocess,
+)
 from utils import DEFAULT_DIM_ORDER as DIM_ORDER
 
 
-def construct_fname(img_path, preprocess_params):
-    suffix = get_params_str(preprocess_params, to_save=True)
-    # Preserve full original filename (including extension) to avoid
-    # Nextflow simpleName stripping dots in param values (e.g. clipLimit=3.0).
-    # Always output as OME-Zarr for intermediates.
-    return Path(f"{Path(img_path).name}_{suffix}.ome.zarr")
+def construct_fname(img_path, params_str):
+    image_id = get_image_id(img_path)
+    param_hash = hash_params_str(params_str)
+    # image_id + a short hash of the preprocessing params (not the raw
+    # string) keeps names short and stops them accumulating a fresh
+    # extension-like segment per pipeline stage. Always output OME-Zarr.
+    return Path(f"{image_id}_{param_hash}.ome.zarr")
 
 
-def save_preprocessed_image(img_path, preprocess_params, prep_image, save_dims):
-    fname = construct_fname(img_path, preprocess_params)
+def save_preprocessed_image(img_path, params_str, prep_image, save_dims):
+    fname = construct_fname(img_path, params_str)
     save_image(prep_image, fname, dim_order=save_dims)
     return fname
 
@@ -60,20 +67,38 @@ if __name__ == "__main__":
     preprocess_methods = load_methods(args.preprocess_params, filter_noop=True)
     # Create a new dataframe to store the new images, repeating rows per preprocessing set
     df_new = pd.concat([df_img.copy()] * len(preprocess_methods), ignore_index=True)
+    # prep_hash's placeholder value is an empty string, which round-trips
+    # through CSV as NaN (float64) if every row happens to be blank;
+    # force it back to string dtype so per-branch hash assignment below
+    # doesn't fail dtype compatibility checks.
+    df_new["prep_hash"] = df_new["prep_hash"].astype(object)
     # Loop over each set and preprocess
     # Derive the dim_order that matches the squeezed data
     save_dims = "".join(d for i, d in enumerate(DIM_ORDER) if i not in squeezed_axes)
+    # Stable identity for the source image, independent of preprocessing branch
+    image_id = get_image_id(args.img_path)
     for i, preprocess_dict in enumerate(preprocess_methods):
         prep_image = run_preprocess(image, methods=preprocess_dict, parse=False)
-        # Get the new filename with embedded preprocessing params
+        params_str = get_params_str(preprocess_dict, to_save=True)
+        # Get the new filename, identified by a short hash of the params
         fname = save_preprocessed_image(
             img_path=args.img_path,
-            preprocess_params=preprocess_dict,
+            params_str=params_str,
             prep_image=prep_image,
             save_dims=save_dims,
         )
         # Update the dataframe with the new image path, ensuring full path given
         df_new.loc[i, "img_path"] = fname
+        # image_id/prep_hash travel onward as plain fields so downstream
+        # naming (getMaskName) never has to re-derive identity from a
+        # filename, or recompute a hash that must stay bit-for-bit
+        # consistent with what aiod_napari independently predicts.
+        # preprocess_params is the structured provenance for this branch,
+        # needed by combine_stacks.py to recover e.g. the downsample factor
+        # without regexing it back out of an (now hashed) filename.
+        df_new.loc[i, "image_id"] = image_id
+        df_new.loc[i, "prep_hash"] = hash_params_str(params_str)
+        df_new.loc[i, "preprocess_params"] = json.dumps(preprocess_dict)
         # Update shape info in the dataframe if downsampled/modified
         if image.shape != prep_image.shape:
             # Re-insert the singleton axes that were squeezed out to restore CZYX identity.


### PR DESCRIPTION
Integrated the other centralised utilities into pipeline with the new simpler output format.

Added new process `computeImageIds` so that we can use the new funcs in utils to do the stripping. Annoying that it adds an extra process, but as we are using the bioio reader extension information we can't have a Groovy translation anymore!

This also now reads the preprocess params in `combine_stacks.py` directly, rather than scraping "downsample" from the filename.