### PR TITLE
Add libgl to conda_combine_stacks.yml dependencies

### DIFF
--- a/modules/models/envs/conda_combine_stacks.yml
+++ b/modules/models/envs/conda_combine_stacks.yml
@@ -12,6 +12,7 @@ dependencies:
   - psutil
   - numba
   - tqdm
+  - libgl
   - pip
   - pip:
     - aiod_utils==0.1


### PR DESCRIPTION
First of all, thanks a lot for this pipeline! I just managed to make it work through the aiod napari plugin inside our Open OnDemand Napari virtual desktop application. 

One minor thing, I had to add `libgl` to the list of dependencies to fix following error:

```
ImportError: libGL.so.1: cannot open shared object file
```
when running splitStacks