### PR TITLE
Fix local file artifact staging for generated model configs

### DIFF
--- a/modules/models/resources/usr/bin/download_model.py
+++ b/modules/models/resources/usr/bin/download_model.py
@@ -102,10 +102,10 @@ def download_from_url(
 
 
 def copy_from_path(fpath: Path | str, chkpt_fname: Path | str):
-    if not Path(fpath).is_file():
-        raise FileNotFoundError(f"Model checkpoint not found: {fpath}")
-    # Copy the file from accessible path
-    shutil.copy(fpath, chkpt_fname)
+    src = Path(fpath)
+    dst = Path(chkpt_fname)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, dst)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

## Summary

Some model configs are generated locally by the plugin and then staged through `downloadArtifact`. In those cases the source config filename can differ from the canonical artifact filename that Nextflow expects.

## What happened

For models such as:

- `cyto / cellpose / cyto3`
- `boundaries / panseg / generic_confocal_3D_unet`

the `downloadArtifact` process exited successfully and printed:

```text
Copying /path/to/generated/config.yaml
```

but Nextflow failed immediately afterwards with a missing output file, for example:

```text
Missing output file(s) `cyto3_cyto_config_423180d0.yml` expected by process `downloadArtifact`
```

## Fix

I changed the local file copy path to treat `--chkpt-fname` as the destination file path, create the parent directory if needed, and copy the source file to that exact path.

This makes the actual copied file match the filename declared as the Nextflow process output.

## Testing

I tested this with AIoD Napari + Nextflow using generated local config files.

After the change, `downloadArtifact` creates the expected config artifact under the model checkpoint cache, and the workflow continues past artifact staging.
