### PR TITLE
AIOD-344: Add per-model substack cap and global tuner

### DIFF
--- a/modules/models/main.nf
+++ b/modules/models/main.nf
@@ -49,7 +49,7 @@ process splitStacks {
     def cap = (params.model_max_substack instanceof Map ? params.model_max_substack[params.model] : null) \
         ?: params.max_substack
     def scale = (params.substack_scale ?: 1.0) as double
-    // null on an axis = uncapped (depth-only tuning); scale only the integer caps
+    // null on an axis = uncapped; scale only the integer caps
     def scaled_cap = cap.collect { it == null ? 'null' : Math.max(1, (it * scale) as int) }
     def cap_arg = "--max-substack ${scaled_cap.join(' ')}"
     """

--- a/modules/models/main.nf
+++ b/modules/models/main.nf
@@ -42,15 +42,24 @@ process splitStacks {
     num_substacks = params.num_substacks.replace(",", " ")
     overlap = params.overlap.replace(",", " ")
     def mem_arg = (params.containsKey('memory_per_job') && params.memory_per_job) \
-        ? "--memory-per-job ${(params.memory_per_job as nextflow.util.MemoryUnit).toBytes()}" \
+        ? "--memory-per-job ${(params.memory_per_job as MemoryUnit).toBytes()}" \
         : ""
+    // Resolve the per-model compute cap (falling back to the global default), then apply the
+    // per-deployment scale so weaker/stronger GPUs can tune all caps with one param.
+    def cap = (params.model_max_substack instanceof Map ? params.model_max_substack[params.model] : null) \
+        ?: params.max_substack
+    def scale = (params.substack_scale ?: 1.0) as double
+    // null on an axis = uncapped (depth-only tuning); scale only the integer caps
+    def scaled_cap = cap.collect { it == null ? 'null' : Math.max(1, (it * scale) as int) }
+    def cap_arg = "--max-substack ${scaled_cap.join(' ')}"
     """
     python ${moduleDir}/resources/usr/bin/create_splits.py \
     --img-csv ${csv_path} \
     --output-csv split_${csv_path} \
     --num-substacks $num_substacks \
     --overlap $overlap \
-    $mem_arg
+    $mem_arg \
+    $cap_arg
     """
 }
 

--- a/modules/models/resources/usr/bin/create_splits.py
+++ b/modules/models/resources/usr/bin/create_splits.py
@@ -44,7 +44,43 @@ if __name__ == "__main__":
         help="Memory available per runModel job in bytes (used to compute substack size dynamically).",
     )
 
+    def _cap_value(s: str) -> int | None:
+        """Parse a --max-substack token: 'null'/'none'/'' -> None (no cap), else int."""
+        return None if s.strip().lower() in ("null", "none", "") else int(s)
+
+    parser.add_argument(
+        "--max-substack",
+        required=False,
+        default=None,
+        nargs=3,
+        type=_cap_value,
+        metavar=("H", "W", "D"),
+        help=(
+            "Per-dimension compute cap on substack size (H W D). Bounds per-job wall time "
+            "(D/slices is the dominant factor). Element-wise min'd with the memory-derived size. "
+            "A value of 'null' leaves that axis uncapped (deferred to the memory budget / whole image) - e.g. 'null null 8' caps depth only. "
+            "If the whole flag is omitted, only the memory cap applies."
+        ),
+    )
+
     args = parser.parse_args()
+
+    def _min_dim(a: int | None, b: int | None) -> int | None:
+        """min of two per-axis caps; None means 'no cap on this axis' -> take the other."""
+        if a is None:
+            return b
+        if b is None:
+            return a
+        return min(a, b)
+
+    def min_stack(a: Stack, b: Stack) -> Stack:
+        """Element-wise min of two caps; None on an axis = uncapped (keep the other)."""
+        return Stack(
+            height=_min_dim(a.height, b.height),
+            width=_min_dim(a.width, b.width),
+            depth=_min_dim(a.depth, b.depth),
+            channels=a.channels if a.channels is not None else b.channels,
+        )
 
     # Load the csv file
     img_csv_fpath = Path(args.img_csv)
@@ -98,13 +134,47 @@ if __name__ == "__main__":
             img_dtype = (
                 str(row["dtype"]) if pd.notna(row["dtype"]) else "float32"
             )  # conservative fallback
-        # Compute the maximum substack size: dynamic if memory_per_job provided, else use constant
+        # Compute the maximum substack size
+        # Dynamic if memory_per_job provided, else use constant
+        # Two independent constraints bound the substack size:
+        #   * memory  ("will it fit in memory?")  -> compute_max_substack_size
+        #   * compute ("will it finish in time?") -> the per-model --max-substack cap
+        # Calc compute cap first, to keep substack H/W large if poss
+        compute_cap = (
+            Stack(*args.max_substack, channels=img_shape.channels)
+            if args.max_substack is not None
+            else None
+        )
+        # Only when memory still binds after compute-capping do both caps apply (element-wise min of the two).
+        # compute_max_substack_size returns its input shape unchanged iff that shape fits the budget
         if args.memory_per_job is not None:
-            max_substack_size = compute_max_substack_size(
-                memory_bytes=args.memory_per_job,
-                dtype=img_dtype,
-                image_shape=img_shape,
-            )
+            if compute_cap is None:
+                max_substack_size = compute_max_substack_size(
+                    memory_bytes=args.memory_per_job,
+                    dtype=img_dtype,
+                    image_shape=img_shape,
+                )
+            else:
+                capped_shape = min_stack(img_shape, compute_cap)
+                fits_memory = (
+                    compute_max_substack_size(
+                        memory_bytes=args.memory_per_job,
+                        dtype=img_dtype,
+                        image_shape=capped_shape,
+                    )
+                    == capped_shape
+                )
+                if fits_memory:
+                    max_substack_size = capped_shape
+                else:
+                    mem_cap = compute_max_substack_size(
+                        memory_bytes=args.memory_per_job,
+                        dtype=img_dtype,
+                        image_shape=img_shape,
+                    )
+                    max_substack_size = min_stack(mem_cap, compute_cap)
+        elif compute_cap is not None:
+            max_substack_size = min_stack(MAX_SUBSTACK_SIZE, compute_cap)
         else:
             max_substack_size = MAX_SUBSTACK_SIZE
         # Get the requested number of substacks (either int or 'auto' for each dimension)
@@ -127,6 +197,10 @@ if __name__ == "__main__":
             # Insert all info from the row
             for key, value in row.items():
                 new_csv[key].append(value)
+            # Ensure a dtype column exists downstream (used to calibrate memory).
+            # Only add it here if the input CSV didn't already carry one (else row.items() did).
+            if fetch_dtype:
+                new_csv["dtype"].append(img_dtype)
             # Add the stack info
             new_csv["stack_idx"].append(i)
             new_csv["start_h"].append(stack[0][0])

--- a/nextflow.config
+++ b/nextflow.config
@@ -51,6 +51,24 @@ params {
     // Substack parameters
     num_substacks = "auto,auto,auto"
     overlap = "0.0,0.0,0.0"
+    // Per-model substack size [H, W, D] cap to limit compute
+    // Element-wise min'd with the memory-derived size (from memory_per_job) in create_splits.py
+    // Global default (also used for models without a per-model entry below)
+    max_substack = [5000, 5000, 50]
+    // Per-model overrides. An axis set to null is uncapped: it defers to the memory budget / whole
+    // image, so H/W tiling only happens if memory forces it
+    // Depth (slices) is the intended chunking lever to control substack runtime
+    // NOTE: These depth values are uncalibrated, a future PR will add a calibration step to set them
+    model_max_substack = [
+        sam2       : [null, null, 8],
+        sam        : [null, null, 8],
+        cellpose   : [null, null, 32],
+        cellposesam: [null, null, 32],
+        empanada   : [null, null, 32],
+    ]
+    // Single, per-deployment lever: scales ALL caps for weaker/stronger GPUs
+    // Override in execution profile (e.g. substack_scale = 0.5 for a weaker GPU -> smaller, faster, wider jobs).
+    substack_scale = 1.0
     // Model parameters
     // NOTE: Defaults here just so that a user can "hello world"-style run the pipeline
     model = "cellpose"

--- a/tests/assets/test_splits_bigvolume.csv
+++ b/tests/assets/test_splits_bigvolume.csv
@@ -1,0 +1,2 @@
+img_path,height,width,num_slices,channels,dtype
+/fake/path/bigvolume_image.tif,8000,8000,1600,1,uint8

--- a/tests/assets/test_splits_hugespatial.csv
+++ b/tests/assets/test_splits_hugespatial.csv
@@ -1,0 +1,2 @@
+img_path,height,width,num_slices,channels,dtype
+/fake/path/hugespatial_image.tif,8000,8000,10,1,float32

--- a/tests/assets/test_splits_regression.csv
+++ b/tests/assets/test_splits_regression.csv
@@ -1,0 +1,2 @@
+img_path,height,width,num_slices,channels,dtype
+/fake/path/regression_image.tif,866,1166,1600,1,uint8

--- a/tests/splitStacks.nf.test
+++ b/tests/splitStacks.nf.test
@@ -4,27 +4,31 @@ nextflow_process {
     process "splitStacks"
 
     // ---------------------------------------------------------------------------
-    // Smoke test: verify that splitStacks passes memory_per_job through to
-    // create_splits.py and produces the expected number of substacks.
+    // Substack sizing is bounded by BOTH a memory budget (memory_per_job) AND a
+    // per-model compute cap (max_substack / model_max_substack, scaled by
+    // substack_scale). create_splits.py takes the element-wise min of the two.
     //
-    // Test image: 2000 × 400 × 100, float32, 1 channel -> 2.56GB
-    // memory_per_job: 100 MB → compute_max_substack_size gives ~(1252, 250, 62)
-    //   → calc_num_stacks gives 2×2×2 = 8 substacks (1 header + 8 data rows)
+    // The first two tests isolate the memory path by setting an effectively
+    // infinite compute cap; the rest exercise the compute cap and its scaling.
     //
     // To run locally (requires Nextflow + conda env):
     //   nf-test test tests/splitStacks.nf.test --profile local
-    //
-    // To run on the cluster (pre-merge CI):
+    // On the cluster (pre-merge CI):
     //   nf-test test tests/splitStacks.nf.test --profile crick
     // ---------------------------------------------------------------------------
 
-    test("8 substacks for 100 MB memory_per_job on 2000x400x100 float32 image") {
+    test("memory path: 8 substacks for 100 MB memory_per_job on 2000x400x100 float32 image") {
 
         when {
             params {
-                num_substacks   = "auto,auto,auto"
-                overlap         = "0.0,0.0,0.0"
-                memory_per_job  = "100.MB"
+                num_substacks      = "auto,auto,auto"
+                overlap            = "0.0,0.0,0.0"
+                memory_per_job     = "100.MB"
+                // Use a model with no per-model cap so the cap is the default [5000,5000,50]
+                // (== old MAX_SUBSTACK_SIZE) — non-interfering here, so this isolates the memory path.
+                model              = "panseg"
+                max_substack       = [5000, 5000, 50]
+                substack_scale     = 1.0
                 root_dir = "."
             }
             process {
@@ -37,29 +41,173 @@ nextflow_process {
 
         then {
             assert process.success
+            def rows = path(process.out.csv_file.get(0)).readLines()
+            assert rows.size() - 1 == 8
+        }
+    }
 
+    test("memory path: succeeds without memory_per_job (falls back to MAX_SUBSTACK_SIZE)") {
+
+        when {
+            params {
+                num_substacks      = "auto,auto,auto"
+                overlap            = "0.0,0.0,0.0"
+                memory_per_job     = null // Explicitly unset to test fallback
+                model              = "panseg" // no per-model cap → default [5000,5000,50]
+                max_substack       = [5000, 5000, 50]
+                substack_scale     = 1.0
+                root_dir = "."
+            }
+            process {
+                """
+                input[0] = file("${projectDir}/tests/assets/test_splits_input.csv")
+                input[1] = file("${projectDir}/tests/assets/dummy_chkpt")
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            def rows = path(process.out.csv_file[0]).readLines()
+            // MAX_SUBSTACK_SIZE (5000×5000×50) on 2000×400×100 → split on depth → 2 rows
+            assert rows.size() - 1 == 2
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Regression guard (PR #19): a spatially-small, many-slice image fits the
+    // memory budget whole, so a memory-only cap yields ONE giant per-slice job.
+    // The per-model compute cap must restore depth chunking → many wide jobs.
+    // 866×1166×1600, cap [4096,4096,8]: H/W untiled, depth 1600/8 = 200 substacks.
+    // ---------------------------------------------------------------------------
+
+    test("compute cap restores depth chunking on many-slice image (regression #19)") {
+
+        when {
+            params {
+                num_substacks      = "auto,auto,auto"
+                overlap            = "0.0,0.0,0.0"
+                memory_per_job     = "50.GB"
+                model              = "sam2"
+                model_max_substack = [sam2: [4096, 4096, 8]]
+                max_substack       = [5000, 5000, 50]
+                substack_scale     = 1.0
+                root_dir = "."
+            }
+            process {
+                """
+                input[0] = file("${projectDir}/tests/assets/test_splits_regression.csv")
+                input[1] = file("${projectDir}/tests/assets/dummy_chkpt")
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            def rows = path(process.out.csv_file.get(0)).readLines()
+            assert rows.size() - 1 == 200
+            // Depth-only chunking: height/width are not tiled (single 0..866 / 0..1166 span).
+            def header = rows[0].split(",") as List
+            def hi = header.indexOf("start_h"); def wi = header.indexOf("start_w")
+            def starts_h = rows[1..-1].collect { it.split(",")[hi] }.toUnique()
+            def starts_w = rows[1..-1].collect { it.split(",")[wi] }.toUnique()
+            assert starts_h == ["0"]
+            assert starts_w == ["0"]
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // substack_scale is the single per-deployment scaler: on a weaker GPU it shrinks
+    // every cap. Halving the depth-8 cap → depth 4 → 1600/4 = 400 substacks.
+    // ---------------------------------------------------------------------------
+
+    test("substack_scale shrinks caps for weaker GPUs") {
+
+        when {
+            params {
+                num_substacks      = "auto,auto,auto"
+                overlap            = "0.0,0.0,0.0"
+                memory_per_job     = "50.GB"
+                model              = "sam2"
+                model_max_substack = [sam2: [4096, 4096, 8]]
+                max_substack       = [5000, 5000, 50]
+                substack_scale     = 0.5
+                root_dir = "."
+            }
+            process {
+                """
+                input[0] = file("${projectDir}/tests/assets/test_splits_regression.csv")
+                input[1] = file("${projectDir}/tests/assets/dummy_chkpt")
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            def rows = path(process.out.csv_file.get(0)).readLines()
+            assert rows.size() - 1 == 400
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Memory cap still binds for spatially-huge images even with a generous depth
+    // cap: 8000×8000×10 @ 1 GB tiles on H/W (and depth) → 2×2×2 = 8 substacks.
+    // ---------------------------------------------------------------------------
+
+    test("memory cap still tiles spatially-huge images") {
+
+        when {
+            params {
+                num_substacks      = "auto,auto,auto"
+                overlap            = "0.0,0.0,0.0"
+                memory_per_job     = "1.GB"
+                model              = "cellpose"
+                model_max_substack = [:]
+                max_substack       = [5000, 5000, 50]
+                substack_scale     = 1.0
+                root_dir = "."
+            }
+            process {
+                """
+                input[0] = file("${projectDir}/tests/assets/test_splits_hugespatial.csv")
+                input[1] = file("${projectDir}/tests/assets/dummy_chkpt")
+                """
+            }
+        }
+
+        then {
+            assert process.success
             def rows = path(process.out.csv_file.get(0)).readLines()
             assert rows.size() - 1 == 8
         }
     }
 
     // ---------------------------------------------------------------------------
-    // Fallback test: when memory_per_job is not set, MAX_SUBSTACK_SIZE is used
-    // and the pipeline still succeeds.
+    // Compute cap + memory must not compound into a gross voxel under-estimate.
+    // A spatially-large, many-slice image (8000×8000×1600, 50 GB) is memory-bound
+    // at full depth, so a naive element-wise min shrinks H/W isotropically (assuming
+    // full depth) AND then clips depth → needless H/W tiling (2×2×200 = 800 tiny jobs).
+    // Applying the compute cap first: 8000×8000×8 fits 50 GB easily, so H/W stay whole
+    // and we get depth-only chunking → 1×1×200 = 200 substacks.
     // ---------------------------------------------------------------------------
 
-    test("succeeds without memory_per_job (falls back to MAX_SUBSTACK_SIZE)") {
+    test("null H/W cap keeps H/W whole, depth-only chunking (no voxel under-estimate)") {
 
         when {
             params {
-                num_substacks = "auto,auto,auto"
-                overlap       = "0.0,0.0,0.0"
-                memory_per_job = null // Explicitly unset to test fallback
+                num_substacks      = "auto,auto,auto"
+                overlap            = "0.0,0.0,0.0"
+                memory_per_job     = "50.GB"
+                model              = "sam2"
+                // null H/W = uncapped (defer to memory); cap depth only — the intended pattern.
+                model_max_substack = [sam2: [null, null, 8]]
+                max_substack       = [5000, 5000, 50]
+                substack_scale     = 1.0
                 root_dir = "."
             }
             process {
                 """
-                input[0] = file("${projectDir}/tests/assets/test_splits_input.csv")
+                input[0] = file("${projectDir}/tests/assets/test_splits_bigvolume.csv")
                 input[1] = file("${projectDir}/tests/assets/dummy_chkpt")
                 """
             }
@@ -67,11 +215,13 @@ nextflow_process {
 
         then {
             assert process.success
-
-            def rows = path(process.out.csv_file[0]).readLines()
-            // With MAX_SUBSTACK_SIZE (5000×5000×50), this image (2000×400×100)
-            // split along depth dimension → 2 rows
-            assert rows.size() - 1 == 2 // subtract header
+            def rows = path(process.out.csv_file.get(0)).readLines()
+            assert rows.size() - 1 == 200
+            // Depth-only: H/W not tiled despite the image being memory-bound at full depth.
+            def header = rows[0].split(",") as List
+            def hi = header.indexOf("start_h"); def wi = header.indexOf("start_w")
+            assert rows[1..-1].collect { it.split(",")[hi] }.toUnique() == ["0"]
+            assert rows[1..-1].collect { it.split(",")[wi] }.toUnique() == ["0"]
         }
     }
 }


### PR DESCRIPTION
As discussed, the recent memory change was a bit static, and unaware of the poor runtime that can occur with some models and images that are low H/W but high D (example was HWD 866x1166x1600).

This PR adds the ability to introduce a substack cap on a per-model basis. Keeping it in Segment-Flow as it's an institution-specific implementation detail not worth putting int the registry. The global `max_substack` is a fallback, used both when a model does not have it's own substack, and to be min'd with the `model_max_substack` when there is either a null, or the memory is dominant.

With this we can max models like SAM parallelise more in depth, and faster (or 3D) models can take more slices per-job.

Note that this is step 1, in a future PR that I'm part-way through will include a separate calibration workflow to assess throughput and memory usage per-model on the specific hardware, and using this to calculate effective pixels/second and work backwards. Anything that comes of the review in this will inform that!